### PR TITLE
chore: Reintroduce outdated to build process

### DIFF
--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -35,3 +35,11 @@ jobs:
               run: cargo build
             - name: Build UI
               run: cargo tauri build --no-bundle                     
+    outdated:
+      name: Outdated
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@v4
+        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/install@cargo-outdated
+        - run: cargo outdated -w -R --exit-code 1   

--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -36,10 +36,10 @@ jobs:
             - name: Build UI
               run: cargo tauri build --no-bundle                     
     outdated:
-      name: Outdated
-      runs-on: ubuntu-22.04
-      steps:
-        - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
-        - uses: dtolnay/install@cargo-outdated
-        - run: cargo outdated -w -R --exit-code 1   
+        name: Outdated
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@stable
+            - uses: dtolnay/install@cargo-outdated
+            - run: cargo outdated -w -R --exit-code 1   


### PR DESCRIPTION
This commit reintroduces the outdated crate to the build process. This is necessary to ensure that the build process is able to detect outdated dependencies and alert the developer to the need to update them.

The outdated crate is now running on each push to a branch, and only checks root dependencies.

Future improvements: None

Breaking changes: None

Resolves: #3