### PR TITLE
chore: Reintroduce clippy to build process

### DIFF
--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -35,3 +35,11 @@ jobs:
               run: cargo build
             - name: Build UI
               run: cargo tauri build --no-bundle                     
+    clippy:
+        name: Clippy
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@clippy
+            - run: cargo clippy --all-targets --all-features -- -D warnings       

--- a/apinae-daemon/src/args.rs
+++ b/apinae-daemon/src/args.rs
@@ -23,17 +23,17 @@ mod test {
 
     #[test]
     fn test_daemon_args() {
-        let args = Args::parse_from(&["apinae-daemon", "--file", "test.json", "--id", "1"]);
+        let args = Args::parse_from(["apinae-daemon", "--file", "test.json", "--id", "1"]);
         assert_eq!(args.file, "test.json");
         assert_eq!(args.id, Some("1".to_string()));
-        assert_eq!(args.list, false);
+        assert!(!args.list);
     }
 
     #[test]
     fn test_daemon_args_list() {
-        let args = Args::parse_from(&["apinae-daemon", "--file", "test.json", "--list"]);
+        let args = Args::parse_from(["apinae-daemon", "--file", "test.json", "--list"]);
         assert_eq!(args.file, "test.json");
         assert_eq!(args.id, None);
-        assert_eq!(args.list, true);
+        assert!(args.list);
     }
 }

--- a/apinae-daemon/tests/test_http_mock.rs
+++ b/apinae-daemon/tests/test_http_mock.rs
@@ -9,6 +9,7 @@ mod common;
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_http_server() {
     // Start the server.
+    #![allow(clippy::zombie_processes)]
     let mut server_command = common::start_server("./tests/resources/test_http_mock.json", "1")
         .await
         .expect("Failed to start server");

--- a/apinae-daemon/tests/test_http_mock_with_proxy.rs
+++ b/apinae-daemon/tests/test_http_mock_with_proxy.rs
@@ -8,13 +8,15 @@ mod common;
  */
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_http_server_with_proxy() {
+    // Start the proxy. Allow zombie process as it's a daemon running.
+    #![allow(clippy::zombie_processes)]    
     let mut tinyproxy_command = Command::new("tinyproxy")
         .arg("-c")
         .arg("./tests/resources/http_tinyproxy.conf")
         .arg("-d")
         .spawn()
         .expect("Failed to start tinyproxy");
-    // Start the server.
+    // Start the server. Allow zombie process as it's a daemon running.
     let mut server_command =
         common::start_server("./tests/resources/test_http_mock_with_proxy.json", "1")
             .await

--- a/apinae-daemon/tests/test_https_mock.rs
+++ b/apinae-daemon/tests/test_https_mock.rs
@@ -8,7 +8,8 @@ mod common;
  */
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_https_server() {
-    // Start the server.
+    // Start the server. Allow zombie process as it's a daemon running.
+    #![allow(clippy::zombie_processes)]
     let mut server_command = common::start_server("./tests/resources/test_https_mock.json", "1")
         .await
         .expect("Failed to start server");

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -332,9 +332,9 @@ mod  test {
 
         assert_eq!(route_row.url, "url");
         assert_eq!(route_row.proxy_url, None);
-        assert_eq!(route_row.http1_only, false);
-        assert_eq!(route_row.accept_invalid_certs, false);
-        assert_eq!(route_row.accept_invalid_hostnames, false);
+        assert!(!route_row.http1_only);
+        assert!(!route_row.accept_invalid_certs);
+        assert!(!route_row.accept_invalid_hostnames);
         assert_eq!(route_row.min_tls_version, None);
         assert_eq!(route_row.max_tls_version, None);
         assert_eq!(route_row.read_timeout, None);


### PR DESCRIPTION
Reintroduce clippy to the build process. This will help us to catch potential issues and improvements in the codebase. The test will fail if clippy detects any issues.

This commit also includes some minor improvements in the codebase to resolve clippy warnings.

Future improvements: None

Breaking changes: None

Resolves: #2