### PR TITLE
feat: Settings component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5473,9 +5473,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
 name = "apinae-lib"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "serde",
  "serde_json",
  "uuid",

--- a/apinae-daemon/Cargo.toml
+++ b/apinae-daemon/Cargo.toml
@@ -15,7 +15,7 @@ apinae-lib = { path = "../apinae-lib" }
 clap = { version = "4.5.31", features = ["derive"] }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-tokio = { version = "1.43.0", features = ["full"] }
+tokio = { version = "1.44.0", features = ["full"] }
 regex = "1.11.1"
 actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
 rustls = { version = "0.23.23", features = ["logging", "tls12"] }

--- a/apinae-lib/Cargo.toml
+++ b/apinae-lib/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = { version = "1.0.140" }
 uuid = { version = "1.15.1", features = ["v4"] }
+dirs = "6.0.0"

--- a/apinae-lib/src/lib.rs
+++ b/apinae-lib/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
 pub mod error;
+pub mod settings;

--- a/apinae-lib/src/settings.rs
+++ b/apinae-lib/src/settings.rs
@@ -1,0 +1,81 @@
+use std::{fs::{DirBuilder, OpenOptions}, io::Write};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ApplicationError;
+
+/**
+ * The settings for the application.
+ */
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Settings {
+    // Use specific apinae command. If none then use the default apinae command will be used.
+    pub apinae_path: Option<String>,
+}
+
+impl Settings {
+    /** 3
+     * Create a new settings object.
+     * 
+     * # Arguments
+     * `apinae_path`: Option<String> - The path to the apinae command.
+     * 
+     * # Returns
+     * Settings - The settings object.
+     */
+    pub fn new(apinae_path: Option<String>) -> Self {
+        Self {
+            apinae_path,
+        }
+    }
+
+    /**
+     * Load settings from a file.
+     *  
+     * # Returns
+     * Settings - The settings object. If any error occurs then the default settings will be returned.
+     */
+    pub fn load() -> Self {
+        match dirs::home_dir() {
+            Some(dir) => {
+                let config_dir = dir.join(".config/apinae");
+                let file_path = config_dir.join("settings.json");        
+                std::fs::read_to_string(file_path).map(|str| {
+                    serde_json::from_str(&str).unwrap_or_default()
+                }).unwrap_or_default()
+            },
+            None => Settings::default(),
+        }
+    }
+
+    /**
+     * Save the settings to a file.
+     * 
+     * # Arguments
+     * `self` - The settings object.
+     * 
+     * # Returns
+     * Result<(), ApplicationError> - The result of saving the settings.
+     */
+    pub fn save(&self) -> Result<(), ApplicationError> {
+        let home_dir = dirs::home_dir().ok_or(ApplicationError::ConfigurationError("Could not find home directory".to_string()))?;
+        let config_dir = home_dir.join(".config/apinae");
+        let file_path = config_dir.join("settings.json");
+        let settings = serde_json::to_string(&self).map_err(|err| ApplicationError::ConfigurationError(err.to_string()))?;
+        let _ = DirBuilder::new().recursive(true).create(config_dir).map_err(|err| ApplicationError::FileError(err.to_string()));
+        let mut file = OpenOptions::new().truncate(true).write(true).create(true).open(file_path).map_err(|err| ApplicationError::FileError(err.to_string()))?; 
+        file.write_all(settings.as_bytes()).map_err(|err| ApplicationError::FileError(err.to_string()))
+    }
+}
+
+impl Default for Settings {
+    /**
+     * Default settings for the application.
+     */
+    fn default() -> Self {
+        Self {
+            apinae_path: None,
+        }
+    }    
+}

--- a/apinae-ui/src-tauri/src/lib.rs
+++ b/apinae-ui/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ mod state;
 
 use state::AppData;
 
-use crate::api::{add_endpoint, add_test, add_server, add_listener, clean, confirm_dialog, delete_endpoint, delete_test, delete_server, delete_listener, get_test, get_servers, get_listeners, get_tests, load, save, save_as, stop_test, start_test, update_endpoint, update_test, update_server, update_listener};
+use crate::api::{load_settings, save_settings, add_endpoint, add_test, add_server, add_listener, clean, confirm_dialog, delete_endpoint, delete_test, delete_server, delete_listener, get_test, get_servers, get_listeners, get_tests, load, save, save_as, stop_test, start_test, update_endpoint, update_test, update_server, update_listener};
 
 /**
  * This function is the entry point of the Tauri application.
@@ -49,7 +49,8 @@ pub fn run() {
             add_endpoint, delete_endpoint, update_endpoint,
             confirm_dialog, 
             start_test, 
-            stop_test])        
+            stop_test,
+            save_settings, load_settings])        
         .run(tauri::generate_context!())
         .expect("Error while running tauri application");
 }

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -121,7 +121,7 @@ impl From<&MockResponseConfiguration> for MockRow {
         Self {
             response: mock.response.clone(),
             status: mock.status,
-            headers: mock.headers.clone().into_iter().map(|(key, value)| format!("{}: {}\n", key, value)).collect::<String>(),
+            headers: mock.headers.iter().fold(String::new(), |mut output, val| { output.push_str(&format!("{}: {}\n", val.0, val.1)); output }),
             delay: mock.delay,
         }
     }

--- a/apinae-ui/src-tauri/~/.config/apinae/settings.json
+++ b/apinae-ui/src-tauri/~/.config/apinae/settings.json
@@ -1,0 +1,1 @@
+{"apinaePath":null}

--- a/apinae-ui/src/App.vue
+++ b/apinae-ui/src/App.vue
@@ -2,6 +2,8 @@
 import { ref } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 
+import settings from "./components/Settings.vue";
+
 const current_file_path = ref("");
 
 const render_route_view = ref(false);
@@ -34,6 +36,11 @@ async function clean() {
     .then((message) => {render_route_view.value = true;})
     .catch((error) => window.alert(error));
 } 
+
+function show_settings() {
+  const modal = new bootstrap.Modal(document.getElementById("idSettingsModal"));
+  modal.show();
+}
 
 </script>
 <style>
@@ -97,7 +104,7 @@ li.dropdown:last-child .dropdown-menu {
                 <li>
                   <hr class="dropdown-divider">
                 </li>
-                <li><a class="dropdown-item" v-on:click=""><i class="fa-solid fa-power-off"></i>&nbsp;Exit</a></li>
+                <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#idSettingsModal"><i class="fas fa-gear"></i>&nbsp;Settings</a></li>
               </ul>
             </li>
           </ul>
@@ -109,4 +116,5 @@ li.dropdown:last-child .dropdown-menu {
       <div class="container">File: {{ current_file_path }}</div>
     </footer>
   </main>
+  <settings></settings>
 </template>

--- a/apinae-ui/src/components/Settings.vue
+++ b/apinae-ui/src/components/Settings.vue
@@ -1,0 +1,84 @@
+<script setup>
+//Required for showing editing modals.
+import { Modal } from 'bootstrap/dist/js/bootstrap.bundle';
+//Required for calling the rust code.
+import { invoke } from "@tauri-apps/api/core";
+
+//Importing the ref function from vue.
+import { onMounted, ref } from "vue";
+
+//The modal for editing settings. Initialized in the onMounted function.
+const editSettingsModal = ref(null);
+
+//The settings data.
+const settingsData = ref({
+    apinaeCommand: "",
+    commandType: ""
+});
+
+// Saves the settings. Calls the rust code to save the settings.
+const saveSettings = () => {
+    invoke("save_settings", { settings: convertToSettingsRequestObject(settingsData.value) })
+        .then((message) => {
+            editSettingsModal.value.hide();
+        })
+    .catch((error) => window.alert(error));
+}
+
+// Converts the settings data to a request object. The request object is used to call the rust code.
+const convertToSettingsRequestObject = (settingsData) => {
+    return {
+        apinaePath: settingsData.commandType == 'specific' ? settingsData.apinaeCommand : null,
+    };
+}
+
+//Called when the component is mounted. Initializes the editSettingsModal and loads the settings.
+onMounted(() => {
+    editSettingsModal.value = new Modal(document.getElementById("idSettingsModal"));
+    invoke("load_settings", {})
+        .then((settings) => {
+            settingsData.value.apinaeCommand = settings.apinaePath;
+            settingsData.value.commandType = settings.apinaePath ? 'specific' : 'installed';
+        })
+        .catch((error) => window.alert(error));
+});
+
+</script>
+<style></style>
+<template>
+    <div id="idSettingsModal" class="modal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Settings</h5>
+                </div>
+                <div class="modal-body">
+                    <form class="row g-3">
+                        <div class="col-md-12">
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" name="commandType" id="idInstalledRadio" value="installed" v-model="settingsData.commandType">
+                                <label class="form-check-label" for="installedRadio">Installed</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" name="commandType" id="idSpecificRadio" value="specific" v-model="settingsData.commandType">
+                                <label class="form-check-label" for="specificRadio">Specific</label>
+                            </div>
+                        </div>
+                        <div class="col-md-12">
+                            <div class="mb-3 row">
+                                <label for="idEditApinaePath" class="col-sm-2 form-label small">Path</label>
+                                <div class="col-sm-10">
+                                    <input type="text" class="form-control form-control-sm" id="idEditApinaePath" v-model="settingsData.apinaeCommand" :disabled="settingsData.commandType === 'installed'">
+                                </div>
+                            </div>                            
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-sm btn-primary" @click="saveSettings()">Save changes</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>


### PR DESCRIPTION
Adds a settings component to the UI that allows the user to change the settings of the application. The settings are stored in a JSON file in the user's home directory. The settings are loaded when the application starts and saved when the user changes them. The settings are also loaded when a test is started.

Currently only the setting for what daemon to use in tests are supported. The settings component is designed to be easily extensible to support more settings in the future.

Future improvements: More settings

Breaking changes: None

Resolves: #4