### PR TITLE
feat: Refactor http endpoint type

### DIFF
--- a/apinae-daemon/Cargo.toml
+++ b/apinae-daemon/Cargo.toml
@@ -12,17 +12,17 @@ categories = ["testing", "api"]
 
 [dependencies]
 apinae-lib = { path = "../apinae-lib" }
-clap = { version = "4.5.31", features = ["derive"] }
-serde = { version = "1.0.218", features = ["derive"] }
+clap = { version = "4.5.32", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-tokio = { version = "1.44.0", features = ["full"] }
+tokio = { version = "1.44.1", features = ["full"] }
 regex = "1.11.1"
-actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
+actix-web = { version = "4.10.2", features = ["rustls-0_23"] }
 rustls = { version = "0.23.23", features = ["logging", "tls12"] }
 rustls-pemfile = "2.2.0"
-reqwest = { version = "0.12.12" }
+reqwest = { version = "0.12.14" }
 log = "0.4.26"
-env_logger = { version = "0.11.6"}
+env_logger = { version = "0.11.7"}
 
 [profile.release]
 lto = true

--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -110,7 +110,7 @@ async fn start_daemon(
     server_setup.setup_test(test).await;
     server_setup.start_servers().await.map_err(|err| {
         ApplicationError::ServerStartUpError(format!("Server startup failed: {err}"))
-    })?; 
+    })?;
     Ok(())
 }
 

--- a/apinae-daemon/tests/resources/test_http_mock.json
+++ b/apinae-daemon/tests/resources/test_http_mock.json
@@ -17,13 +17,17 @@
                             "pathExpression": "^\/test$",
                             "method": "GET",
                             "soapAction": null,
-                            "mock": {
-                                "response": "{ \"test\": \"Success http\" }",
-                                "status": 200,
-                                "headers": {
-                                    "Content-Type": "application/json"
-                                },
-                                "delay": 0
+                            "endpointType": {
+                                "mock": {
+                                    "configuration": {
+                                        "response": "{ \"test\": \"Success http\" }",
+                                        "status": 200,
+                                        "headers": {
+                                            "Content-Type": "application/json"
+                                        },
+                                        "delay": 0
+                                    }
+                                }
                             }
                         },
                         {
@@ -31,13 +35,17 @@
                             "pathExpression": "^\/test$",
                             "method": "POST",
                             "soapAction": null,
-                            "mock": {
-                                "response": "{ \"test\": \"Success http\" }",
-                                "status": 201,
-                                "headers": {
-                                    "Content-Type": "application/json"
-                                },
-                                "delay": 0
+                            "endpointType": {
+                                "mock": {
+                                    "configuration": {
+                                        "response": "{ \"test\": \"Success http\" }",
+                                        "status": 200,
+                                        "headers": {
+                                            "Content-Type": "application/json"
+                                        },
+                                        "delay": 0
+                                    }
+                                }
                             }
                         }                        
                     ]

--- a/apinae-daemon/tests/resources/test_http_mock_with_proxy.json
+++ b/apinae-daemon/tests/resources/test_http_mock_with_proxy.json
@@ -16,12 +16,14 @@
                             "id": "0a583546-5d23-4fa1-a053-543df7b6fce5",
                             "pathExpression": "^\/test$",
                             "method": "GET",
-                            "soapAction": null,
-                            "route": {
-                                "url": "http://localhost:8082",
-                                "proxyUrl": "http://localhost:8081"
-
-                            }
+                            "endpointType": {
+                                "route": {
+                                    "configuration": {
+                                        "url": "http://localhost:8082",
+                                        "proxyUrl": "http://localhost:8081"
+                                    }
+                                }
+                            }                            
                         }
                     ]
                 },
@@ -34,14 +36,17 @@
                             "id": "0a583546-5d23-4fa1-a053-543df7b6fce5",
                             "pathExpression": "^\/test$",
                             "method": "GET",
-                            "soapAction": null,
-                            "mock": {
-                                "response": "{ \"test\": \"Success http\" }",
-                                "status": 200,
-                                "headers": {
-                                    "Content-Type": "application/json"
-                                },
-                                "delay": 0
+                            "endpointType": {
+                                "mock": {
+                                    "configuration": {
+                                        "response": "{ \"test\": \"Success http\" }",
+                                        "status": 200,
+                                        "headers": {
+                                            "Content-Type": "application/json"
+                                        },
+                                        "delay": 0
+                                    }
+                                }
                             }
                         }
                     ]

--- a/apinae-daemon/tests/resources/test_https_mock.json
+++ b/apinae-daemon/tests/resources/test_https_mock.json
@@ -20,20 +20,23 @@
               "id": "0a583546-5d23-4fa1-a053-543df7b6fce5",
               "pathExpression": "^\/test$",
               "method": "GET",
-              "soapAction": null,
-              "mock": {
-                "response": "{ \"test\": \"Success https\" }",
-                "status": 200,
-                "headers": {
-                  "Content-Type": "application/json"
-                },
-                "delay": 0
+              "endpointType": {
+                "mock": {
+                  "configuration": {
+                    "response": "{ \"test\": \"Success https\" }",
+                    "status": 200,
+                    "headers": {
+                      "Content-Type": "application/json"
+                    },
+                    "delay": 0
+                  }
+                }
               }
             }
           ]
         }
       ],
-      "listeners": []      
+      "listeners": []
     }
   ]
 }

--- a/apinae-daemon/tests/test_listener_mock.rs
+++ b/apinae-daemon/tests/test_listener_mock.rs
@@ -24,6 +24,9 @@ async fn test_tcp_listener() {
     server_command.kill().expect("Failed to kill process");    
 }
 
+/**
+ * Asserts the server response.
+ */
 async fn assert_command(server_command: &mut Child, port : &str, expected: &str) {   
     let connect = format!("http://localhost:{}", port);     
     let nc_command = match Command::new("curl")

--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::{model::{EndpointRow, HttpServerRow, TcpListenerRow, TestRow}, state::ProcessData};
 use tauri::{AppHandle, State};
 use crate::AppData;
-use apinae_lib::{config::{AppConfiguration, CloseConnectionWhen, EndpointConfiguration, HttpsConfiguration, MockResponseConfiguration, RouteConfiguration, ServerConfiguration, TcpListenerData, TestConfiguration}, settings::Settings};
+use apinae_lib::{config::{AppConfiguration, CloseConnectionWhen, EndpointConfiguration, EndpointType, HttpsConfiguration, ServerConfiguration, TcpListenerData, TestConfiguration}, settings::Settings};
 use tauri_plugin_dialog::{DialogExt, FilePath, MessageDialogButtons};
 
 /**
@@ -327,14 +327,8 @@ pub async fn get_listeners(app_data: State<'_, AppData>, testid: &str) -> Result
 #[tauri::command]
 pub async fn update_listener(app_data: State<'_, AppData>, testid: &str, listenerid: &str, tcplistener: TcpListenerRow) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
-    let test = data.tests.iter_mut().find(|t| t.id == testid).ok_or("Test not found")?;
-    let tcp_listener_index = test.listeners.iter_mut().position(|s| s.id == listenerid).ok_or("Listener not found")?;
-    test.listeners[tcp_listener_index].port = tcplistener.port;
-    test.listeners[tcp_listener_index].file = tcplistener.file;
-    test.listeners[tcp_listener_index].data = tcplistener.data;
-    test.listeners[tcp_listener_index].delay_write_ms = tcplistener.delay_write_ms;
-    test.listeners[tcp_listener_index].accept = tcplistener.accept;
-    test.listeners[tcp_listener_index].close_connection = CloseConnectionWhen::from(tcplistener.close_connection.as_str());    
+    let mut listener = data.get_listener(testid, listenerid).ok_or("Listener not found")?;
+    listener.update(tcplistener.file, tcplistener.data, tcplistener.delay_write_ms, tcplistener.port, tcplistener.accept, CloseConnectionWhen::from(tcplistener.close_connection.as_str()));
     update_data(&app_data, Some(data))?;
     Ok(())
 }
@@ -396,7 +390,7 @@ pub async fn add_listener(app_data: State<'_, AppData>, testid: &str) -> Result<
 pub async fn add_endpoint(app_data: State<'_, AppData>, testid: &str, serverid: &str) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
     let server = data.get_server(testid, serverid).ok_or("Server not found")?;
-    server.endpoints.push(EndpointConfiguration::new("/".to_owned(), String::new(), None, None).map_err(|err| err.to_string())?);
+    server.endpoints.push(EndpointConfiguration::new("/".to_owned(), String::new(), None).map_err(|err| err.to_string())?);
     update_data(&app_data, Some(data))?;
     Ok(())
 }
@@ -438,12 +432,18 @@ pub async fn delete_endpoint(app_data: State<'_, AppData>, testid: &str, serveri
  * If the server could not be found.
  * If the endpoint could not be updated.
  */
+#[allow(clippy::manual_map)]
 #[tauri::command]
 pub async fn update_endpoint(app_data: State<'_, AppData>, testid: &str, serverid: &str, endpointid: &str, endpoint: EndpointRow) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
-    let mock_response = endpoint.mock.map(MockResponseConfiguration::from);
-    let route_response = endpoint.route.map(RouteConfiguration::from);
-    data.update_endpoint(testid, serverid, endpointid, endpoint.path_expression.as_str(), endpoint.method.as_str(), mock_response, route_response).map_err(|err| err.to_string())?;
+    let endpoint_type = if let Some(mock_response) = &endpoint.mock {
+        Some(EndpointType::Mock { configuration: mock_response.into() })
+    } else if let Some(route_response) = &endpoint.route {
+        Some(EndpointType::Route { configuration: route_response.into() })
+    } else {
+        None
+    };  
+    data.update_endpoint(testid, serverid, endpointid, endpoint.path_expression.as_str(), endpoint.method.as_str(), endpoint_type).map_err(|err| err.to_string())?;
     update_data(&app_data, Some(data))?;
     Ok(())
 }


### PR DESCRIPTION
This commit refactors the http endpoint type to be more flexible by using an emum rather than multiple optional fields. By doing this it allows for more flexibility in the future. The new enum is called EndpointType and has the following variants:
- Route
- Mock

Future improvements: Add more tests for the new enum.

Breaking changes: None

Resolves: #21