### PR TITLE
fix: Update listener data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6025,9 +6025,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
  "serde",

--- a/apinae-lib/Cargo.toml
+++ b/apinae-lib/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-uuid = { version = "1.15.1", features = ["v4"] }
+uuid = { version = "1.16.0", features = ["v4"] }
 dirs = "6.0.0"

--- a/apinae-lib/src/config.rs
+++ b/apinae-lib/src/config.rs
@@ -220,9 +220,13 @@ impl AppConfiguration {
         accept: bool,
         close_connection: CloseConnectionWhen,
     ) -> Result<(), ApplicationError> {
-        let mut listener = self.get_listener(test_id, listener_id).ok_or_else(|| {
-            ApplicationError::CouldNotFind(format!("Listener with id {listener_id} not found."))
-        })?;
+        let listener = self.get_test(test_id).and_then(|test| {
+            test.listeners
+                .iter_mut()
+                .find(|listener| listener.id == listener_id)
+        }).ok_or(ApplicationError::CouldNotFind(format!(
+            "Listener with id {listener_id} not found."
+        )))?;
         listener.file = file;
         listener.data = data;
         listener.delay_write_ms = delay_write_ms;

--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -327,8 +327,7 @@ pub async fn get_listeners(app_data: State<'_, AppData>, testid: &str) -> Result
 #[tauri::command]
 pub async fn update_listener(app_data: State<'_, AppData>, testid: &str, listenerid: &str, tcplistener: TcpListenerRow) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
-    let mut listener = data.get_listener(testid, listenerid).ok_or("Listener not found")?;
-    listener.update(tcplistener.file, tcplistener.data, tcplistener.delay_write_ms, tcplistener.port, tcplistener.accept, CloseConnectionWhen::from(tcplistener.close_connection.as_str()));
+    data.update_listener(testid, listenerid, tcplistener.file, tcplistener.data, tcplistener.delay_write_ms, tcplistener.port, tcplistener.accept, CloseConnectionWhen::from(tcplistener.close_connection.as_str())).map_err(|err| err.to_string())?;
     update_data(&app_data, Some(data))?;
     Ok(())
 }


### PR DESCRIPTION
Fixes a bug where the listener data was not being updated. The cause was due to cloned data not being updated in the listener data. This commit fixes the issue by updating the listener data with the new data.

Future improvements None

Breaking changes: None

Resolves: #23