### PR TITLE
fix: fix endpoint initialization

### DIFF
--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -1,15 +1,28 @@
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use crate::{model::{EndpointRow, HttpServerRow, TcpListenerRow, TestRow}, state::ProcessData};
 use tauri::{AppHandle, State};
 use crate::AppData;
-use apinae_lib::{config::{AppConfiguration, CloseConnectionWhen, EndpointConfiguration, EndpointType, HttpsConfiguration, ServerConfiguration, TcpListenerData, TestConfiguration}, settings::Settings};
+use apinae_lib::{config::{AppConfiguration, CloseConnectionWhen, EndpointConfiguration, EndpointType, HttpsConfiguration, MockResponseConfiguration, ServerConfiguration, TcpListenerData, TestConfiguration}, settings::Settings};
 use tauri_plugin_dialog::{DialogExt, FilePath, MessageDialogButtons};
 
 /**
  * Default name for new tests, servers, listeners and endpoints.
  */
 const DEFAULT_NAME: &str = "Untitled";
+/**
+ * Default status code for new mock responses.
+ */
+const DEFAULT_STATUS_CODE: u16 = 200;
+/**
+ * Default delay for new mock responses.
+ */
+const DEFAULT_DELAY: u64 = 0;
+
+/**
+ * Default method for new endpoints.
+ */
+const DEFAULT_METHOD: &str = "GET";
 
 /**
  * Loads the configuration from a file.
@@ -389,7 +402,7 @@ pub async fn add_listener(app_data: State<'_, AppData>, testid: &str) -> Result<
 pub async fn add_endpoint(app_data: State<'_, AppData>, testid: &str, serverid: &str) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
     let server = data.get_server(testid, serverid).ok_or("Server not found")?;
-    server.endpoints.push(EndpointConfiguration::new("/".to_owned(), String::new(), None).map_err(|err| err.to_string())?);
+    server.endpoints.push(EndpointConfiguration::new("/".to_owned(), DEFAULT_METHOD.to_owned(), Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(None, DEFAULT_STATUS_CODE, HashMap::new(), DEFAULT_DELAY) })).map_err(|err| err.to_string())?);
     update_data(&app_data, Some(data))?;
     Ok(())
 }

--- a/apinae-ui/src/components/Test.vue
+++ b/apinae-ui/src/components/Test.vue
@@ -408,7 +408,7 @@ const validateStringRequired = (str) => {
 
 //Verify that input is a number. 
 const validateNumberRequired = (str) => {
-  if (str && (Number.isInteger(str) || (str.length > 0 && !isNaN(str)))) {
+  if (typeof str === "number" || (str && (Number.isInteger(str) || (str.length > 0 && !isNaN(str))))) {
     return "is-valid";
   }
   return "is-invalid";
@@ -416,7 +416,7 @@ const validateNumberRequired = (str) => {
 
 //Verify that input is a number or null. 
 const validateNumberOptional = (str) => {
-  if (!str || (Number.isInteger(str) || (str.length > 0 && !isNaN(str)))) {
+  if (typeof str === "number" || (!str || (Number.isInteger(str) || (str.length > 0 && !isNaN(str))))) {
     return "is-valid";
   }
   return "is-invalid"; 


### PR DESCRIPTION
Fixes the endpoint initialization so that when the endpoint is added to the configuration, it is initalized in an ok state. This is done by adding ok values when initializing the endpoint.

This also fixes an issue in the Test.vue component when the delay is set to 0. This caused the validation to fail as the value was a number and not a string. The value is now success when retrieved as a number.

Future improvements: None

Breaking changes: None

Resolves: #27