### PR TITLE
fix: startup requires input

### DIFF
--- a/apinae-ui/src/App.vue
+++ b/apinae-ui/src/App.vue
@@ -6,7 +6,7 @@ import settings from "./components/Settings.vue";
 
 const current_file_path = ref("");
 
-const render_route_view = ref(false);
+const render_route_view = ref(true);
 
 async function load() {
   render_route_view.value = false;


### PR DESCRIPTION
Fixes an issue when the application is started it does not show an empty project as default. This caused the user to have to select a project or new project before the application could be used.

Future improvements: Initialize with previous project used

Breaking changes: None

Resolves: #29