### PR TITLE
build: simplify compile and test flow

### DIFF
--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -25,16 +25,8 @@ jobs:
               run: cargo fetch
             - name: Compile
               run: cargo build
-            - name: Compile and test
-              run: cargo test -- --test-threads=1
-            - name: Install cargo Tauri
-              run: cargo install tauri-cli
-            - name: install frontend dependencies
-              run: npm install --prefix apinae-ui      
-            - name: Build daemon
-              run: cargo build
-            - name: Build UI
-              run: cargo tauri build --no-bundle                     
+            - name: Test
+              run: cargo test -- --test-threads=1                 
     clippy:
         name: Clippy
         runs-on: ubuntu-22.04


### PR DESCRIPTION
Simplifies compile and test flow by removing the UI build step. This is because the UI build step is very slow. This change will speed up the build and test process.

Future improvements: None

Breaking changes: None

Resolves: #33