### PR TITLE
feat: support input parameters

### DIFF
--- a/apinae-daemon/src/args.rs
+++ b/apinae-daemon/src/args.rs
@@ -25,15 +25,14 @@ pub struct Args {
 }
 
 /// Parse a single key-value pair
-fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>> where
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
+where
     T: std::str::FromStr,
     T::Err: Error + Send + Sync + 'static,
     U: std::str::FromStr,
     U::Err: Error + Send + Sync + 'static,
 {
-    let pos = s
-        .find('=')
-        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+    let pos = s.find('=').ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 

--- a/apinae-daemon/src/args.rs
+++ b/apinae-daemon/src/args.rs
@@ -1,7 +1,9 @@
+use std::error::Error;
+
 use clap::Parser;
 
 /// Command line application for starting daemon and reading test configurations.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None, author="Kjetil Fjellheim")]
 pub struct Args {
     /// Input file.
@@ -15,6 +17,24 @@ pub struct Args {
     /// Lists the available tests in the specified file.
     #[arg(long)]
     pub list: bool,
+
+    /// Parameter values for the test. Multiple parameters can be specified.
+    /// This is a key-value pair separated by `=`. For example: `key=value`.
+    #[arg(long, value_parser = parse_key_val::<String, String>)]
+    pub param: Vec<(String, String)>,
+}
+
+/// Parse a single key-value pair
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>> where
+    T: std::str::FromStr,
+    T::Err: Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
 #[cfg(test)]

--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -130,8 +130,8 @@ fn validate_parameters(test: &TestConfiguration, args: &Args) -> Result<(), Appl
         return Ok(());
     }
     for param in test_params {
-        if !args.param.iter().find(|(key, _)| key.eq(param)).is_none() {
-            return Err(ApplicationError::CouldNotFind(format!("Missing parameter: {}", param)));
+        if !args.param.iter().any(|(key, _)| key.eq(param)) {
+            return Err(ApplicationError::CouldNotFind(format!("Missing parameter: {param}")));
         }
     }
     Ok(())    

--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -109,7 +109,7 @@ async fn start_daemon(args: Args, config: &AppConfiguration) -> Result<(), Appli
 }
 
 /**
- * Validate the parameters for the test. 
+ * Validate the parameters for the test.
  * All test parameters must be specified in the arguments.
  *
  * # Arguments
@@ -132,7 +132,7 @@ fn validate_parameters(test: &TestConfiguration, args: &Args) -> Result<(), Appl
             return Err(ApplicationError::CouldNotFind(format!("Missing parameter: {param}")));
         }
     }
-    Ok(())    
+    Ok(())
 }
 
 /**
@@ -253,5 +253,4 @@ mod test {
         let args_params_ok = Args::parse_from(["apinae-daemon", "--file", "./tests/resources/test_http_mock.json", "--id", "1", "--param", "param2=2", "--param", "param1=1"]);
         assert_eq!(validate_parameters(config.tests.first().unwrap(), &args_params_ok), Ok(()));
     }
-
 }

--- a/apinae-daemon/src/server/http.rs
+++ b/apinae-daemon/src/server/http.rs
@@ -664,7 +664,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_generate_mock_response() {
         let mock_response = MockResponseConfiguration::new(Some("Test".to_owned()), String::from("200"), HashMap::new(), 0);
-        let response = generate_mock_response(&mock_response, &Vec::new()).await;
+        let response = generate_mock_response(&mock_response, Vec::new()).await;
         assert!(response.is_ok());
     }
 

--- a/apinae-daemon/src/server/setup.rs
+++ b/apinae-daemon/src/server/setup.rs
@@ -3,6 +3,8 @@ use std::rc::Rc;
 use apinae_lib::{config::TestConfiguration, error::ApplicationError};
 use tokio::sync::RwLock;
 
+use crate::args::Args;
+
 use super::{common::StartableServer, http::AppServer, tcp::AppListener};
 
 /**
@@ -26,10 +28,10 @@ impl ServerSetup {
     /**
      * Setup the test with the specified configuration. This also initalizes the app servers.
      */
-    pub async fn setup_test(&mut self, test_configuration: &TestConfiguration) {
+    pub async fn setup_test(&mut self, test_configuration: &TestConfiguration, args: Args) {
         log::info!("Setting up test with id {}", test_configuration.id);
         let servers: Vec<Box<dyn StartableServer>> =
-            test_configuration.servers.iter().map(|server_configuration| Box::new(AppServer::new(server_configuration.clone())) as Box<dyn StartableServer>).collect();
+            test_configuration.servers.iter().map(|server_configuration| Box::new(AppServer::new(server_configuration.clone(), args.param.clone())) as Box<dyn StartableServer>).collect();
         let listeners: Vec<Box<dyn StartableServer>> = test_configuration.listeners.iter().map(|tcp_listener_data| Box::new(AppListener::new(tcp_listener_data)) as Box<dyn StartableServer>).collect();
         self.servers.write().await.extend(servers);
         self.servers.write().await.extend(listeners);
@@ -57,9 +59,11 @@ impl ServerSetup {
 mod tests {
     use super::*;
     use apinae_lib::config::ServerConfiguration;
+    use clap::Parser;
 
     #[tokio::test]
     async fn test_setup_test() {
+        let args: Args = Args::parse_from(["apinae-daemon", "--file", "./tests/resources/test_http_mock.json", "--id", "1"]);
         let mut server_setup = ServerSetup::new();
         let test_configuration = TestConfiguration {
             id: "test".to_string(),
@@ -69,7 +73,7 @@ mod tests {
             listeners: vec![],
             params: None,
         };
-        server_setup.setup_test(&test_configuration).await;
+        server_setup.setup_test(&test_configuration, args).await;
         let servers = server_setup.start_servers().await;
         assert!(servers.is_ok());
     }

--- a/apinae-daemon/src/server/setup.rs
+++ b/apinae-daemon/src/server/setup.rs
@@ -67,6 +67,7 @@ mod tests {
             description: "Test description".to_string(),
             servers: vec![ServerConfiguration { id: "test".to_string(), name: "Test server".to_string(), http_port: Some(8080), https_config: None, endpoints: vec![] }],
             listeners: vec![],
+            params: None,
         };
         server_setup.setup_test(&test_configuration).await;
         let servers = server_setup.start_servers().await;

--- a/apinae-daemon/tests/resources/test_http_mock_with_param.json
+++ b/apinae-daemon/tests/resources/test_http_mock_with_param.json
@@ -6,6 +6,7 @@
             "id": "1",
             "name": "Test",
             "description": "Test Description",
+            "params": ["param1", "param2"],
             "servers": [
                 {
                     "id": "1",
@@ -29,25 +30,7 @@
                                     }
                                 }
                             }
-                        },
-                        {
-                            "id": "0a583546-5d23-4fa1-a053-543df7b6fce5",
-                            "pathExpression": "^\/test$",
-                            "method": "POST",
-                            "soapAction": null,
-                            "endpointType": {
-                                "mock": {
-                                    "configuration": {
-                                        "response": "{ \"test\": \"Success http\" }",
-                                        "status": "200",
-                                        "headers": {
-                                            "Content-Type": "application/json"
-                                        },
-                                        "delay": 0
-                                    }
-                                }
-                            }
-                        }                        
+                        }                      
                     ]
                 }
             ],

--- a/apinae-daemon/tests/resources/test_http_mock_with_proxy.json
+++ b/apinae-daemon/tests/resources/test_http_mock_with_proxy.json
@@ -40,7 +40,7 @@
                                 "mock": {
                                     "configuration": {
                                         "response": "{ \"test\": \"Success http\" }",
-                                        "status": 200,
+                                        "status": "200",
                                         "headers": {
                                             "Content-Type": "application/json"
                                         },

--- a/apinae-daemon/tests/resources/test_https_mock.json
+++ b/apinae-daemon/tests/resources/test_https_mock.json
@@ -24,7 +24,7 @@
                 "mock": {
                   "configuration": {
                     "response": "{ \"test\": \"Success https\" }",
-                    "status": 200,
+                    "status": "200",
                     "headers": {
                       "Content-Type": "application/json"
                     },

--- a/apinae-lib/src/config.rs
+++ b/apinae-lib/src/config.rs
@@ -56,10 +56,11 @@ impl AppConfiguration {
      * # Errors
      * An error if the test could not be found.
      */
-    pub fn update_test(&mut self, test_id: &str, name: &str, description: &str) -> Result<(), ApplicationError> {
+    pub fn update_test(&mut self, test_id: &str, name: &str, description: &str, params: Option<HashSet<String>>) -> Result<(), ApplicationError> {
         let test = self.get_test(test_id).ok_or_else(|| ApplicationError::CouldNotFind(format!("Test with id {test_id} not found.")))?;
         test.name = name.to_string();
         test.description = description.to_string();
+        test.params = params;
         Ok(())
     }
 

--- a/apinae-lib/src/config.rs
+++ b/apinae-lib/src/config.rs
@@ -274,6 +274,9 @@ impl AppConfiguration {
      * 
      * `test_id` The id of the test.
      * `param` The parameter to add.
+     * 
+     * # Errors
+     * An error if the test could not be found.
      */
     pub fn add_param(&mut self, test_id: &str, param: String) -> Result<(), ApplicationError> {
         let test = self.get_test(test_id).ok_or_else(|| ApplicationError::CouldNotFind(format!("Test with id {test_id} not found.")))?;
@@ -286,6 +289,9 @@ impl AppConfiguration {
      * 
      * `test_id` The id of the test.
      * `param` The parameter to remove.
+     * 
+     * # Errors
+     * An error if the test could not be found.
      */
     pub fn remove_param(&mut self, test_id: &str, param: &str) -> Result<(), ApplicationError> {
         let test = self.get_test(test_id).ok_or_else(|| ApplicationError::CouldNotFind(format!("Test with id {test_id} not found.")))?;
@@ -651,7 +657,7 @@ pub struct MockResponseConfiguration {
     // The response to return when the mock is called.
     pub response: Option<String>,
     // The status code to return when the mock is called.
-    pub status: u16,
+    pub status: String,
     // The headers to return when the mock is called.
     pub headers: HashMap<String, String>,
     // Time to wait in milliseconds before returning the response.
@@ -671,7 +677,7 @@ impl MockResponseConfiguration {
      * The mock response configuration.
      */
     #[must_use]
-    pub fn new(response: Option<String>, status: u16, headers: HashMap<String, String>, delay: u64) -> Self {
+    pub fn new(response: Option<String>, status: String, headers: HashMap<String, String>, delay: u64) -> Self {
         MockResponseConfiguration { response, status, headers, delay }
     }
 }
@@ -891,7 +897,7 @@ mod test {
                         Some("/test".to_string()),
                         Some("".to_string()),
                         Some("GET".to_string()),
-                        Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(Some("Test Response".to_string()), 200, HashMap::new(), 0) }),
+                        Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(Some("Test Response".to_string()), String::from("200"), HashMap::new(), 0) }),
                     )
                     .unwrap()],
                     None,
@@ -924,7 +930,7 @@ mod test {
                         Some("/test".to_string()),
                         Some("".to_string()),
                         Some("GET".to_string()),
-                        Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(Some("Test Response".to_string()), 200, HashMap::new(), 0) }),
+                        Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(Some("Test Response".to_string()), String::from("200"), HashMap::new(), 0) }),
                     )
                     .unwrap()],
                     None,                    

--- a/apinae-lib/src/config.rs
+++ b/apinae-lib/src/config.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::{HashMap, HashSet}, time::SystemTime};
+use std::{
+    collections::{HashMap, HashSet},
+    time::SystemTime,
+};
 
 use crate::error::ApplicationError;
 
@@ -260,7 +263,16 @@ impl AppConfiguration {
      * An error if the endpoint could not be found.
      */
     #[allow(clippy::too_many_arguments)]
-    pub fn update_endpoint(&mut self, test_id: &str, server_id: &str, endpoint_id: &str, path_expression: Option<String>, body_expression: Option<String>, method: Option<String>, endpoint_type: Option<EndpointType>) -> Result<(), ApplicationError> {
+    pub fn update_endpoint(
+        &mut self,
+        test_id: &str,
+        server_id: &str,
+        endpoint_id: &str,
+        path_expression: Option<String>,
+        body_expression: Option<String>,
+        method: Option<String>,
+        endpoint_type: Option<EndpointType>,
+    ) -> Result<(), ApplicationError> {
         let endpoint = self.get_endpoint(test_id, server_id, endpoint_id).ok_or_else(|| ApplicationError::CouldNotFind(format!("Endpoint with id {endpoint_id} not found.")))?;
         endpoint.path_expression = path_expression;
         endpoint.method = method;
@@ -271,10 +283,10 @@ impl AppConfiguration {
 
     /**
      * Add parameter to the test.
-     * 
+     *
      * `test_id` The id of the test.
      * `param` The parameter to add.
-     * 
+     *
      * # Errors
      * An error if the test could not be found.
      */
@@ -286,10 +298,10 @@ impl AppConfiguration {
 
     /**
      * Remove parameter from the test.
-     * 
+     *
      * `test_id` The id of the test.
      * `param` The parameter to remove.
-     * 
+     *
      * # Errors
      * An error if the test could not be found.
      */
@@ -373,7 +385,7 @@ impl TestConfiguration {
 
     /**
      * Add a parameter to the test.
-     * 
+     *
      * `param` The parameter to add.
      */
     pub fn add_param(&mut self, param: String) {
@@ -387,7 +399,7 @@ impl TestConfiguration {
     }
     /**
      * Delete a parameter from the test.
-     * 
+     *
      * `param` The parameter to delete.
      */
     pub fn remove_param(&mut self, param: &str) {
@@ -398,7 +410,6 @@ impl TestConfiguration {
             }
         }
     }
-
 }
 
 /**
@@ -664,7 +675,6 @@ pub struct MockResponseConfiguration {
     pub delay: u64,
 }
 
-
 impl MockResponseConfiguration {
     /**
      * Create a new mock response configuration.
@@ -852,11 +862,11 @@ mod test {
                         Some(EndpointType::Route { configuration: RouteConfiguration::new("/test".to_string(), None, None, false, false, false, None, None, None, None) }),
                     )
                     .unwrap()],
-                    None,                    
+                    None,
                 )
                 .unwrap()],
                 Vec::new(),
-                None
+                None,
             )
             .unwrap()],
         );
@@ -933,7 +943,7 @@ mod test {
                         Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(Some("Test Response".to_string()), String::from("200"), HashMap::new(), 0) }),
                     )
                     .unwrap()],
-                    None,                    
+                    None,
                 )
                 .unwrap()],
                 Vec::new(),

--- a/apinae-lib/src/error.rs
+++ b/apinae-lib/src/error.rs
@@ -1,7 +1,7 @@
 /**
  * This module contains the error type for the application.
  */
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ApplicationError {
     FileError(String),
     MissingId(String),

--- a/apinae-lib/src/settings.rs
+++ b/apinae-lib/src/settings.rs
@@ -58,7 +58,7 @@ impl Settings {
      *
      * # Returns
      * The result of saving the settings.
-     * 
+     *
      * # Errors
      * If any error occurs while saving the settings, an `ApplicationError` will be returned.
      */

--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -19,7 +19,7 @@ const DEFAULT_NAME: &str = "Untitled";
 /**
  * Default status code for new mock responses.
  */
-const DEFAULT_STATUS_CODE: u16 = 200;
+const DEFAULT_STATUS_CODE: &str = "200";
 /**
  * Default delay for new mock responses.
  */
@@ -415,7 +415,7 @@ pub async fn add_endpoint(app_data: State<'_, AppData>, testid: &str, serverid: 
             Some("/".to_owned()),
             Some("GET".to_owned()),
             Some(String::new()),
-            Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(None, DEFAULT_STATUS_CODE, HashMap::new(), DEFAULT_DELAY) }),
+            Some(EndpointType::Mock { configuration: MockResponseConfiguration::new(None, DEFAULT_STATUS_CODE.to_string(), HashMap::new(), DEFAULT_DELAY) }),
         )
         .map_err(|err| err.to_string())?,
     );

--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -175,7 +175,7 @@ pub async fn get_test(app_data: State<'_, AppData>, testid: &str) -> Result<Test
 #[tauri::command]
 pub async fn add_test(app_data: State<'_, AppData>) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
-    data.tests.push(TestConfiguration::new(DEFAULT_NAME.to_owned(), String::new(), Vec::new(), Vec::new()).map_err(|err| err.to_string())?);
+    data.tests.push(TestConfiguration::new(DEFAULT_NAME.to_owned(), String::new(), Vec::new(), Vec::new(), None).map_err(|err| err.to_string())?);
     update_data(&app_data, Some(data))?;
     Ok(())
 }

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -90,7 +90,7 @@ pub struct EndpointRow {
     // The method of the endpoint.
     pub method: Option<String>,
     // The body expression.
-    pub body_expression: Option<String>,    
+    pub body_expression: Option<String>,
     // The mock response of the endpoint.
     pub mock: Option<MockRow>,
     // The route configuration of the endpoint.
@@ -435,7 +435,7 @@ mod test {
      */
     #[test]
     fn test_from_mockrow_to_mockresponseconfiguration_no_header() {
-        let mock_row = MockRow { response: None, status: String::from("200"), headers:String::new(), delay: 0 };
+        let mock_row = MockRow { response: None, status: String::from("200"), headers: String::new(), delay: 0 };
 
         let mock_config = MockResponseConfiguration::from(&mock_row);
 

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use apinae_lib::config::{EndpointConfiguration, EndpointType, HttpsConfiguration, MockResponseConfiguration, RouteConfiguration, ServerConfiguration, TcpListenerData, TestConfiguration, TlsVersion};
 
 /**
@@ -14,6 +16,8 @@ pub struct TestRow {
     pub description: String,
     // The process id of the test.
     pub process_id: Option<u32>,
+    // The parameters of the test.
+    pub params: Option<HashSet<String>>
 }
 
 impl TestRow {
@@ -25,12 +29,13 @@ impl TestRow {
      * `name` - The name of the test.
      * `description` - The description of the test.
      * `process_id` - The process id of the test.
+     * `params` - The parameters of the test.
      *
      * # Returns
      * `TestRow` - The test row.
      */
-    pub fn new(id: &str, name: &str, description: &str, process_id: Option<u32>) -> Self {
-        Self { id: id.to_string(), name: name.to_string(), description: description.to_string(), process_id }
+    pub fn new(id: &str, name: &str, description: &str, process_id: Option<u32>, params: Option<HashSet<String>>) -> Self {
+        Self { id: id.to_string(), name: name.to_string(), description: description.to_string(), process_id , params}
     }
 }
 
@@ -39,7 +44,7 @@ impl From<TestConfiguration> for TestRow {
      * Convert a test configuration to a test row.
      */
     fn from(test: TestConfiguration) -> Self {
-        Self { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None }
+        Self { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None, params: test.params }
     }
 }
 

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -128,7 +128,7 @@ pub struct MockRow {
     // The response of the mock.
     pub response: Option<String>,
     // The status response of the mock.
-    pub status: u16,
+    pub status: String,
     // The headers of the mock.
     pub headers: String,
     // The delay for writing responses.
@@ -142,7 +142,7 @@ impl From<&MockResponseConfiguration> for MockRow {
     fn from(mock: &MockResponseConfiguration) -> Self {
         Self {
             response: mock.response.clone(),
-            status: mock.status,
+            status: mock.status.clone(),
             headers: mock.headers.iter().fold(String::new(), |mut output, val| {
                 output.push_str(&format!("{}: {}\n", val.0, val.1));
                 output
@@ -159,7 +159,7 @@ impl From<&MockRow> for MockResponseConfiguration {
     fn from(mock: &MockRow) -> Self {
         MockResponseConfiguration::new(
             mock.response.clone(),
-            mock.status,
+            mock.status.clone(),
             mock.headers
                 .split('\n')
                 .filter(|header| !header.is_empty() && header.contains(':'))
@@ -370,12 +370,12 @@ mod test {
 
     #[test]
     fn test_mock_row_from_mock_response_configuration() {
-        let mock_config = MockResponseConfiguration::new(None, 200, HashMap::new(), 0);
+        let mock_config = MockResponseConfiguration::new(None, String::from("200"), HashMap::new(), 0);
 
         let mock_row = MockRow::from(&mock_config);
 
         assert_eq!(mock_row.response, None);
-        assert_eq!(mock_row.status, 200);
+        assert_eq!(mock_row.status, String::from("200"));
         assert_eq!(mock_row.headers, String::new());
         assert_eq!(mock_row.delay, 0);
     }
@@ -418,12 +418,12 @@ mod test {
      */
     #[test]
     fn test_from_mockrow_to_mockresponseconfiguration() {
-        let mock_row = MockRow { response: Some("response".to_owned()), status: 200, headers: "header: value\nheader2:\n \n".to_owned(), delay: 0 };
+        let mock_row = MockRow { response: Some("response".to_owned()), status: String::from("200"), headers: "header: value\nheader2:\n \n".to_owned(), delay: 0 };
 
         let mock_config = MockResponseConfiguration::from(&mock_row);
 
         assert_eq!(mock_config.response, Some("response".to_owned()));
-        assert_eq!(mock_config.status, 200);
+        assert_eq!(mock_config.status, String::from("200"));
         assert_eq!(mock_config.headers.get("header"), Some(&"value".to_owned()));
         assert_eq!(mock_config.headers.get("header2"), Some(&String::new()));
         assert_eq!(mock_config.delay, 0);
@@ -435,12 +435,12 @@ mod test {
      */
     #[test]
     fn test_from_mockrow_to_mockresponseconfiguration_no_header() {
-        let mock_row = MockRow { response: None, status: 200, headers:String::new(), delay: 0 };
+        let mock_row = MockRow { response: None, status: String::from("200"), headers:String::new(), delay: 0 };
 
         let mock_config = MockResponseConfiguration::from(&mock_row);
 
         assert_eq!(mock_config.response, None);
-        assert_eq!(mock_config.status, 200);
+        assert_eq!(mock_config.status, String::from("200"));
         assert_eq!(mock_config.headers.len(), 0);
         assert_eq!(mock_config.delay, 0);
     }

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -337,7 +337,7 @@ mod test {
 
     #[test]
     fn test_test_row_from_test_configuration() {
-        let test_config = TestConfiguration::new("name".to_owned(), "description".to_owned(), Vec::new(), Vec::new()).unwrap();
+        let test_config = TestConfiguration::new("name".to_owned(), "description".to_owned(), Vec::new(), Vec::new(), None).unwrap();
 
         let test_row = TestRow::from(test_config);
 

--- a/apinae-ui/src/components/Tests.vue
+++ b/apinae-ui/src/components/Tests.vue
@@ -11,6 +11,10 @@ const tests = ref([]);
 //The data is copied from the tests object to the editTestData object.
 const editTestData = ref({});
 
+// Parameter data for adding a new parameter to the test.
+//This is called when the user clicks the add button in the edit test modal.
+const editAddParameter = ref("");
+
 //Refreshes the tests array by calling the get_tests function in the backend.
 //This is called when the component is mounted and when a test is added, updated, or deleted.
 const refresh = () => {
@@ -99,21 +103,34 @@ const validateStringRequired = (str) => {
     return "is-invalid";
 }
 
-//Verify that input is a number. 
-const validateNumberRequired = (str) => {
-    if (str && (Number.isInteger(str) || (str.length > 0 && !isNaN(str)))) {
-        return "is-valid";
+// Adds a parameter to the test.
+//This is called when the user clicks the add button in the edit test modal.
+//The parameter is added to the params array of the test. The editAddParameter object is cleared.
+//If the parameter is empty, it is not added to the params array.
+const addParameter = () => {
+    if (editAddParameter.value && editAddParameter.value.length > 0) {
+        if (!editTestData.value.params) {
+            editTestData.value.params = [];
+        }
+        editTestData.value.params.push(editAddParameter.value);
+        editAddParameter.value = "";
     }
-    return "is-invalid";
 }
 
-//Verify that input is a number or null. 
-const validateNumberOptional = (str) => {
-    if (!str || (Number.isInteger(str) || (str.length > 0 && !isNaN(str)))) {
-        return "is-valid";
+//Removes a parameter from the test.
+//This is called when the user clicks the remove parameter button in the edit test modal.
+const removeParameter = (param) => {
+    if (editTestData.value.params) {
+        const index = editTestData.value.params.indexOf(param);
+        if (index > -1) {
+            editTestData.value.params.splice(index, 1);
+        }
+        if (editTestData.value.params.length === 0) {
+            editTestData.value.params = null;
+        }
     }
-    return "is-invalid";
 }
+
 </script>
 <style>
 /* The max height is full view height minus (top bar, menu bar and status bar + margins) */
@@ -161,6 +178,7 @@ const validateNumberOptional = (str) => {
                                     <th scope="col">Id</th>
                                     <th scope="col">Name</th>
                                     <th scope="col">Description</th>
+                                    <th scope="col">Parameters</th>
                                     <th scope="col"></th>
                                     <th scope="col"></th>
                                 </tr>
@@ -171,9 +189,15 @@ const validateNumberOptional = (str) => {
                                     </td>
                                     <td class="align-middle"><label class="align-middle small">{{ test.name }}</label>
                                     </td>
-                                    <td class="align-middle"><label class="align-middle small">{{ test.description
-                                            }}</label>
+                                    <td class="align-middle"><label class="align-middle small">{{ test.description }}</label>
                                     </td>
+                                    <td class="align-middle">
+                                        <template v-if="test.params">
+                                            <template v-for="param in test.params" :key="param">
+                                                <span class="badge bg-info-subtle text-primary small">{{ param }}</span>&nbsp;
+                                            </template>
+                                        </template>
+                                    </td>                                    
                                     <td class="align-middle">
                                         <span class="align-middle">
                                             <div class="btn-toolbar" role="toolbar"
@@ -212,12 +236,9 @@ const validateNumberOptional = (str) => {
                                 </tr>
                             </tbody>
                         </table>
-
+                        
                     </div>
                 </div>
-
-
-
             </div>
         </div>
     </div>
@@ -245,6 +266,18 @@ const validateNumberOptional = (str) => {
                         <label for="idEditDescription" class="form-label small">Description</label>
                         <textarea class="form-control form-control-sm is-valid" id="idEditDescription" rows="3"
                             v-model="editTestData.description"></textarea>
+                    </div>
+                    <div class="mb-3">                        
+                        <label for="idEditParams" class="form-label small">Parameters</label>
+                        <div class="input-group mb-3">
+                            <input type="text" class="form-control is-valid" placeholder="Parameter" aria-label="Parameter" v-model="editAddParameter">
+                            <button class="btn btn-outline-primary" type="button" id="addParameter" @click="addParameter()">Add</button>
+                        </div>                                                
+                        <template v-if="editTestData.params">
+                            <template v-for="param in editTestData.params" :key="param">
+                                <button type="button" class="btn btn-sm btn-info small" @click="removeParameter(param)">{{ param }}</button>&nbsp;
+                            </template>
+                        </template>
                     </div>
                 </div>
                 <div class="modal-footer bg-primary-subtle">


### PR DESCRIPTION
Adds support for input parameters in the API. This allows users to pass parameters to the mock returns so that they can be reused across different requests. The parameters are defined in the configuration file and can be used in the mock returns.

Future improvements: None

Breaking changes: None

Resolves: #54