### PR TITLE
fix: statuscode not updateable

### DIFF
--- a/apinae-ui/src/components/Test.vue
+++ b/apinae-ui/src/components/Test.vue
@@ -333,7 +333,7 @@ const convertEndpointToRequestObject = (editEndpointData, editMockData, editRout
 
 const convertMockToRequestObject = (mockData) => {
   return {
-    status: mockData.value.status ? parseInt(mockData.value.status) : null,
+    status: mockData.value.status ? mockData.value.status : null,
     headers: mockData.value.headers,
     delay: parseInt(mockData.value.delay),
     response: mockData.value.response


### PR DESCRIPTION
Fixes an issue where the status code is not updatable. The reason for this is that the status code is not being set as a string, but rather being converted to integer in the ui. This issue just removes the conversion to integer.

Future improvements: None

Breaking changes: None

Resolves: #56