### PR TITLE
feat: add list params argument

### DIFF
--- a/apinae-daemon/src/args.rs
+++ b/apinae-daemon/src/args.rs
@@ -22,6 +22,10 @@ pub struct Args {
     /// This is a key-value pair separated by `=`. For example: `key=value`.
     #[arg(long, value_parser = parse_key_val::<String, String>)]
     pub param: Vec<(String, String)>,
+
+    /// List all parameters for the test.
+    #[arg(long)]
+    pub list_params: bool,
 }
 
 /// Parse a single key-value pair


### PR DESCRIPTION
Adds argument to list parameters for a test. The argument is --list-params and must be used with file and id arguments. The parameters are listed in a table format.

Also fixes a bug where the application won't exit after list-params and list-tests commands are called.

Future improvements: None

Breaking changes: None

Resolves: #58