### PR TITLE
feat: sort params

### DIFF
--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::{collections::HashMap, path::Path};
 
 use crate::AppData;
@@ -194,7 +195,12 @@ pub async fn add_test(app_data: State<'_, AppData>) -> Result<(), String> {
 #[tauri::command]
 pub async fn update_test(app_data: State<'_, AppData>, testid: &str, test: TestRow) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
-    data.update_test(testid, test.name.as_str(), test.description.as_str(), test.params.clone()).map_err(|err| err.to_string())?;
+    data.update_test(
+        testid,
+        test.name.as_str(),
+        test.description.as_str(),
+        test.params.map(|f| f.iter().cloned().collect::<HashSet<_>>()),
+    ).map_err(|err| err.to_string())?;
     update_data(&app_data, Some(data))?;
     Ok(())
 }
@@ -524,7 +530,7 @@ pub async fn start_test(app_data: State<'_, AppData>, testid: &str) -> Result<Te
     let test = app_config.tests.iter().find(|t| t.id == testid).ok_or("Test not found")?;
     let mut process_data = app_data.process_data.lock().map_err(|err| err.to_string())?;
     if let Some(process_data) = process_data.get(testid) {
-        Ok(TestRow { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: Some(process_data.process_id), params: test.params.clone() })
+        Ok(TestRow { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: Some(process_data.process_id), params: test.clone().params.map(|f| f.iter().cloned().collect::<Vec<_>>()) })
     } else {
         let file_path = get_current_file_path(&app_data)?;
         let path = Path::new(&file_path).parent().or_else(|| Some(Path::new("."))).ok_or("Invalid file path")?;
@@ -561,9 +567,9 @@ pub async fn stop_test(app_data: State<'_, AppData>, testid: &str) -> Result<Tes
         Some(process_data) => {
             process_data.process.kill().map_err(|err| err.to_string())?;
             processes_data.remove(testid);
-            Ok(TestRow { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None, params: test.params.clone() })
+            Ok(TestRow { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None, params: test.clone().params.map(|f| f.iter().cloned().collect::<Vec<_>>())})
         }
-        None => Ok(TestRow { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None, params: test.params.clone() }),
+        None => Ok(TestRow { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None, params: test.clone().params.map(|f| f.iter().cloned().collect::<Vec<_>>()) }),
     }
 }
 

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -17,7 +17,7 @@ pub struct TestRow {
     // The process id of the test.
     pub process_id: Option<u32>,
     // The parameters of the test.
-    pub params: Option<HashSet<String>>
+    pub params: Option<Vec<String>>
 }
 
 impl TestRow {
@@ -35,7 +35,7 @@ impl TestRow {
      * `TestRow` - The test row.
      */
     pub fn new(id: &str, name: &str, description: &str, process_id: Option<u32>, params: Option<HashSet<String>>) -> Self {
-        Self { id: id.to_string(), name: name.to_string(), description: description.to_string(), process_id , params}
+        Self { id: id.to_string(), name: name.to_string(), description: description.to_string(), process_id, params: params.map(|p| p.into_iter().collect()) }
     }
 }
 
@@ -44,7 +44,12 @@ impl From<TestConfiguration> for TestRow {
      * Convert a test configuration to a test row.
      */
     fn from(test: TestConfiguration) -> Self {
-        Self { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None, params: test.params }
+        Self { id: test.id.clone(), name: test.name.clone(), description: test.description.clone(), process_id: None, params: test.params.map(|f| {
+            let mut params = f.iter().cloned().collect::<Vec<_>>();
+            params.sort();
+            params
+        }) 
+        }
     }
 }
 

--- a/apinae-ui/src/components/Tests.vue
+++ b/apinae-ui/src/components/Tests.vue
@@ -113,7 +113,7 @@ const addParameter = () => {
             editTestData.value.params = [];
         }
         editTestData.value.params.push(editAddParameter.value);
-        editAddParameter.value = "";
+        editAddParameter.value = "";        
     }
 }
 
@@ -275,7 +275,7 @@ const removeParameter = (param) => {
                         </div>                                                
                         <template v-if="editTestData.params">
                             <template v-for="param in editTestData.params" :key="param">
-                                <button type="button" class="btn btn-sm btn-info small" @click="removeParameter(param)">{{ param }}</button>&nbsp;
+                                <button type="button" class="btn btn-sm btn-outline-primary small" @click="removeParameter(param)">{{ param }}</button>
                             </template>
                         </template>
                     </div>


### PR DESCRIPTION
Changes the params element to be a sorted array in the model. The sorting occurs when converting the config model to the ui model. This is done to make reading the params easier in the UI. The sorting is done by alphabethic order of the param name. The sorting is done in the model.rs file.

Changes the ui for the params so they are easier to read.

Future improvements: None

Breaking changes: None

Resolves: #60