### PR TITLE
feat: add verify argument

### DIFF
--- a/apinae-daemon/src/args.rs
+++ b/apinae-daemon/src/args.rs
@@ -26,6 +26,13 @@ pub struct Args {
     /// List all parameters for the test.
     #[arg(long)]
     pub list_params: bool,
+
+    /// Verify daemon initialization. Stops the server after initialization.
+    /// This is useful for testing the daemon without running it.
+    #[arg(long)]
+    pub verify: bool,
+
+    
 }
 
 /// Parse a single key-value pair


### PR DESCRIPTION
Adds argument --verify to the apinae daemon to verify the configuration file. In this mode the daemon will start, but immediately exit after initialization. This is useful for checking the configuration file syntax and values. It also allows for more complex tests.

Future improvements: None

Breaking changes: None

Resolves: #67