### PR TITLE
feat: add predefined parameter sets

### DIFF
--- a/apinae-daemon/src/args.rs
+++ b/apinae-daemon/src/args.rs
@@ -32,7 +32,10 @@ pub struct Args {
     #[arg(long)]
     pub verify: bool,
 
-    
+    /// Use this predefined set of parameters for the test.
+    #[arg(long)]
+    pub predefined_set: Option<String>,
+
 }
 
 /// Parse a single key-value pair

--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -125,9 +125,9 @@ fn list_tests(config: &AppConfiguration) {
 async fn start_daemon(args: Args, config: &AppConfiguration) -> Result<(), ApplicationError> {
     let test_id = args.clone().id.ok_or(ApplicationError::CouldNotFind("Missing id".to_string()))?;
     let test = get_test(test_id.as_str(), config)?;
-    validate_parameters(test, &args)?;
+    let params = validate_parameters(test, &args)?;
     let mut server_setup = ServerSetup::new();
-    server_setup.setup_test(test, args.clone()).await;
+    server_setup.setup_test(test, params).await?;
     server_setup.start_servers().await.map_err(|err| ApplicationError::ServerStartUpError(format!("Server startup failed: {err}")))?;
     if args.verify {
         return Ok(());
@@ -152,17 +152,33 @@ async fn start_daemon(args: Args, config: &AppConfiguration) -> Result<(), Appli
  * # Errors
  * An error if the parameters are invalid.
  */
-fn validate_parameters(test: &TestConfiguration, args: &Args) -> Result<(), ApplicationError> {
-    let test_params = &test.params.clone().unwrap_or_default();
-    if test_params.is_empty() {
-        return Ok(());
-    }
-    for param in test_params {
-        if !args.param.iter().any(|(key, _)| key.eq(param)) {
-            return Err(ApplicationError::CouldNotFind(format!("Missing parameter: {param}")));
+fn validate_parameters(test: &TestConfiguration, args: &Args) -> Result<Vec<(String, String)>, ApplicationError> {
+    let test_params_required = &test.params.clone().unwrap_or_default();
+    let mut test_params = Vec::new();
+    if let Some(predefined_set_name) = &args.predefined_set {
+        log::info!("Using predefined set {predefined_set_name}");
+        let predefined_set = get_predefined_set(test, predefined_set_name)?;
+        test_params.extend(predefined_set.values.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }    
+    for (key, value) in &args.param {
+        if test_params_required.iter().any(|param| param.eq(key)) {
+            test_params.push((key.clone(), value.clone()));
+        } else {
+            return Err(ApplicationError::CouldNotFind(format!("Parameter {key} not found in test {}", test.id)));
         }
     }
-    Ok(())
+    if test_params_required.is_empty() {
+        return Ok(Vec::new());
+    }    
+    for required_param in test_params_required {
+        if !args.param.iter().any(|(key, _)| key.eq(required_param)) {
+            return Err(ApplicationError::CouldNotFind(format!("Missing parameter: {required_param}")));
+        }
+    }
+    if test_params_required.len() != test_params.len() {
+        return Err(ApplicationError::CouldNotFind(format!("Missing parameters: {:?}", test_params_required)));
+    }
+    Ok(test_params)
 }
 
 /**
@@ -184,6 +200,26 @@ fn get_test<'a>(id: &str, config: &'a AppConfiguration) -> Result<&'a TestConfig
         Some(test) => Ok(test),
         None => Err(ApplicationError::CouldNotFind(format!("No test with id: {id}"))),
     }
+}
+
+/**
+ * Get predefined set for a test.
+ *
+ * # Arguments
+ * `test_configuration`: The test configuration to get the predefined set from.
+ * `predefined_set_name`: The name of the predefined set to get.
+ *
+ * # Returns
+ * Ok if the predefined set was found.
+ *
+ * # Errors
+ * An error if the predefined set was not found.
+ */
+fn get_predefined_set(test_configuration: &TestConfiguration, predefined_set_name: &String) -> Result<apinae_lib::config::PredefinedSet, ApplicationError> {
+    let predefined_set = test_configuration.clone().predefined_params
+        .and_then(|f| f.iter().find(|p| p.name == *predefined_set_name).cloned())
+        .ok_or_else(|| ApplicationError::CouldNotFind("Predefined set not found".to_string()))?;
+    Ok(predefined_set)
 }
 
 /**
@@ -281,6 +317,6 @@ mod test {
         let args_missing_param1 = Args::parse_from(["apinae-daemon", "--file", "./tests/resources/test_http_mock.json", "--id", "1", "--param", "param2=2"]);
         assert_eq!(validate_parameters(config.tests.first().unwrap(), &args_missing_param1), Err(ApplicationError::CouldNotFind("Missing parameter: param1".to_string())));
         let args_params_ok = Args::parse_from(["apinae-daemon", "--file", "./tests/resources/test_http_mock.json", "--id", "1", "--param", "param2=2", "--param", "param1=1"]);
-        assert_eq!(validate_parameters(config.tests.first().unwrap(), &args_params_ok), Ok(()));
+        assert_eq!(validate_parameters(config.tests.first().unwrap(), &args_params_ok), Ok(vec![("param2".to_string(), "2".to_string()), ("param1".to_string(), "1".to_string())]));
     }
 }

--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -176,7 +176,7 @@ fn validate_parameters(test: &TestConfiguration, args: &Args) -> Result<Vec<(Str
         }
     }
     if test_params_required.len() != test_params.len() {
-        return Err(ApplicationError::CouldNotFind(format!("Missing parameters: {:?}", test_params_required)));
+        return Err(ApplicationError::CouldNotFind(format!("Missing parameters: {test_params_required:?}")));
     }
     Ok(test_params)
 }

--- a/apinae-lib/src/config.rs
+++ b/apinae-lib/src/config.rs
@@ -331,6 +331,8 @@ pub struct TestConfiguration {
     pub listeners: Vec<TcpListenerData>,
     // The parameters to pass to the test.
     pub params: Option<HashSet<String>>,
+    // Predefined sets of parameters.
+    pub predefined_params: Option<Vec<PredefinedSet>>,
 }
 
 impl TestConfiguration {
@@ -340,13 +342,16 @@ impl TestConfiguration {
      * `name` The name of the test.
      * `description` The description of the test.
      * `servers` The server configurations.
+     * `listeners` The TCP listeners.
+     * `params` The parameters to pass to the test.
+     * `predefined_params` The predefined sets of parameters.
      *
      * # Errors
      * An error if the identifier could not be generated.
      */
-    pub fn new(name: String, description: String, servers: Vec<ServerConfiguration>, listeners: Vec<TcpListenerData>, params: Option<HashSet<String>>) -> Result<Self, ApplicationError> {
+    pub fn new(name: String, description: String, servers: Vec<ServerConfiguration>, listeners: Vec<TcpListenerData>, params: Option<HashSet<String>>, predefined_params: Option<Vec<PredefinedSet>>) -> Result<Self, ApplicationError> {
         let id = get_identifier()?;
-        Ok(TestConfiguration { id, name, description, servers, listeners, params })
+        Ok(TestConfiguration { id, name, description, servers, listeners, params, predefined_params })
     }
 
     /**
@@ -411,6 +416,17 @@ impl TestConfiguration {
             }
         }
     }
+}
+
+/**
+ * Predefined parameters.
+ */
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PredefinedSet {
+    // Name of the predefined set.
+    pub name: String,
+    pub values: HashMap<String, String>,
 }
 
 /**
@@ -863,10 +879,11 @@ mod test {
                         Some(EndpointType::Route { configuration: RouteConfiguration::new("/test".to_string(), None, None, false, false, false, None, None, None, None) }),
                     )
                     .unwrap()],
-                    None,
+                    None,                    
                 )
                 .unwrap()],
                 Vec::new(),
+                None,
                 None,
             )
             .unwrap()],
@@ -916,6 +933,7 @@ mod test {
                 .unwrap()],
                 Vec::new(),
                 None,
+                None,
             )
             .unwrap()],
         );
@@ -948,6 +966,7 @@ mod test {
                 )
                 .unwrap()],
                 Vec::new(),
+                None,
                 None,
             )
             .unwrap()],

--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -176,7 +176,7 @@ pub async fn get_test(app_data: State<'_, AppData>, testid: &str) -> Result<Test
 #[tauri::command]
 pub async fn add_test(app_data: State<'_, AppData>) -> Result<(), String> {
     let mut data = get_configuration_data(&app_data)?;
-    data.tests.push(TestConfiguration::new(DEFAULT_NAME.to_owned(), String::new(), Vec::new(), Vec::new(), None).map_err(|err| err.to_string())?);
+    data.tests.push(TestConfiguration::new(DEFAULT_NAME.to_owned(), String::new(), Vec::new(), Vec::new(), None, None).map_err(|err| err.to_string())?);
     update_data(&app_data, Some(data))?;
     Ok(())
 }

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -352,7 +352,7 @@ mod test {
 
     #[test]
     fn test_test_row_from_test_configuration() {
-        let test_config = TestConfiguration::new("name".to_owned(), "description".to_owned(), Vec::new(), Vec::new(), None).unwrap();
+        let test_config = TestConfiguration::new("name".to_owned(), "description".to_owned(), Vec::new(), Vec::new(), None, None).unwrap();
 
         let test_row = TestRow::from(test_config);
 


### PR DESCRIPTION
Allows users to define parameter sets in the config file, which can be used to quickly switch between different configurations. The predefined parameter sets are defined in the config file and can be selected using the `--predefined_set=<name>` flag.

Predefined parameters can be used in conjunction  with --param flags. The --param flags will not override the parameters defined in the predefined set.

Future improvements: Add override functionality for --param flags to override the parameters defined in the predefined set.

Breaking changes: None

Resolves: #64