### PR TITLE
feat: edit parameter sets

### DIFF
--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -247,6 +247,69 @@ pub async fn get_predefined_sets(app_data: State<'_, AppData>, testid: &str) -> 
 }
 
 /**
+ * Adds a predefined set.
+ * 
+ * `app_data` The application data.
+ * `testid` The test id.
+ * 
+ * # Errors
+ * If the configuration data could not be locked.
+ * If the test could not be found.
+ * If the predefined set could not be added.
+ */
+#[tauri::command]
+pub async fn add_predefined_set(app_data: State<'_, AppData>, testid: &str) -> Result<(), String> {
+    let mut data = get_configuration_data(&app_data)?;
+    let test = data.get_test(testid).ok_or("Test not found")?;
+    test.add_new_predefined_param_set().map_err(|err| err.to_string())?;
+    update_data(&app_data, Some(data))?;
+    Ok(()) 
+}
+
+/**
+ * Deletes a predefined set.
+ *
+ * `app_data` The application data.
+ * `testid` The test id.
+ * `name` The name of the predefined set.
+ *
+ * # Errors
+ * If the configuration data could not be locked.
+ * If the test could not be found.
+ * If the predefined set could not be deleted.
+ */
+#[tauri::command]
+pub fn delete_predefined_set(app_data: State<'_, AppData>, testid: &str, name: &str) -> Result<(), String> {
+    let mut data = get_configuration_data(&app_data)?;
+    let test = data.get_test(testid).ok_or("Test not found")?;
+    test.delete_predefined_param_set(name).map_err(|err| err.to_string())?;
+    update_data(&app_data, Some(data))?;
+    Ok(())
+}
+
+/**
+ * Updates a predefined set.
+ *
+ * `app_data` The application data.
+ * `testid` The test id.
+ * `old_name` The old name of the predefined set.
+ * `predified_set` The predefined set.
+ *
+ * # Errors
+ * If the configuration data could not be locked.
+ * If the test could not be found.
+ * If the predefined set could not be updated.
+ */
+#[tauri::command]
+pub fn update_predefined_set(app_data: State<'_, AppData>, testid: &str, old_name: &str, predefined_set: PredefinedSet) -> Result<(), String> {
+    let mut data = get_configuration_data(&app_data)?;
+    let test = data.get_test(testid).ok_or("Test not found")?;
+    test.update_predefined_param_set(old_name, &predefined_set.name, predefined_set.values.clone()).map_err(|err| err.to_string())?;
+    update_data(&app_data, Some(data))?;
+    Ok(())
+}
+
+/**
  * Gets the servers.
  *
  * `app_data` The application data.

--- a/apinae-ui/src-tauri/src/api.rs
+++ b/apinae-ui/src-tauri/src/api.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::{collections::HashMap, path::Path};
 
+use crate::model::PredefinedSet;
 use crate::AppData;
 use crate::{
     model::{EndpointRow, HttpServerRow, TcpListenerRow, TestRow},
@@ -216,6 +217,33 @@ pub async fn delete_test(app_data: State<'_, AppData>, testid: &str) -> Result<(
     data.delete_test(testid).map_err(|err| err.to_string())?;
     update_data(&app_data, Some(data))?;
     Ok(())
+}
+
+/**
+ * Gets the predefined sets.
+ *
+ * `app_data` The application data.
+ * `testid` The test id.
+ *
+ * Returns:
+ * The predefined sets.
+ *
+ * # Errors
+ * If the configuration data could not be locked.
+ * If the test could not be found.
+ */
+#[tauri::command]
+pub async fn get_predefined_sets(app_data: State<'_, AppData>, testid: &str) -> Result<Vec<PredefinedSet>, String> {
+    let mut data = get_configuration_data(&app_data)?;
+    let test = data.get_test(testid).ok_or("Test not found")?;
+    let mut sets: Vec<PredefinedSet> = Vec::new();    
+    if let Some(predefined_params) = &test.predefined_params {
+        for predefined_set in predefined_params {
+            let set = PredefinedSet::new(&predefined_set.name.clone(), predefined_set.values.clone());
+            sets.push(set);
+        }
+    }
+    Ok(sets)
 }
 
 /**

--- a/apinae-ui/src-tauri/src/lib.rs
+++ b/apinae-ui/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use state::AppData;
 
 use crate::api::{
     add_endpoint, add_listener, add_server, add_test, clean, confirm_dialog, delete_endpoint, delete_listener, delete_server, delete_test, get_listeners, get_servers, get_test, get_tests, load,
-    load_settings, open_dialog, save, save_as, save_settings, start_test, stop_test, update_endpoint, update_listener, update_server, update_test,
+    load_settings, open_dialog, save, save_as, save_settings, start_test, stop_test, update_endpoint, update_listener, update_server, update_test, get_predefined_sets,
 };
 
 /**
@@ -62,6 +62,7 @@ pub fn run() {
             update_listener,
             add_listener,
             delete_listener,
+            get_predefined_sets,
             add_endpoint,
             delete_endpoint,
             update_endpoint,

--- a/apinae-ui/src-tauri/src/lib.rs
+++ b/apinae-ui/src-tauri/src/lib.rs
@@ -2,11 +2,12 @@ mod api;
 mod model;
 mod state;
 
+use api::update_predefined_set;
 use state::AppData;
 
 use crate::api::{
     add_endpoint, add_listener, add_server, add_test, clean, confirm_dialog, delete_endpoint, delete_listener, delete_server, delete_test, get_listeners, get_servers, get_test, get_tests, load,
-    load_settings, open_dialog, save, save_as, save_settings, start_test, stop_test, update_endpoint, update_listener, update_server, update_test, get_predefined_sets,
+    load_settings, open_dialog, save, save_as, save_settings, start_test, stop_test, update_endpoint, update_listener, update_server, update_test, get_predefined_sets, add_predefined_set, delete_predefined_set,
 };
 
 /**
@@ -63,6 +64,9 @@ pub fn run() {
             add_listener,
             delete_listener,
             get_predefined_sets,
+            add_predefined_set,
+            delete_predefined_set,
+            update_predefined_set,
             add_endpoint,
             delete_endpoint,
             update_endpoint,

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use apinae_lib::config::{EndpointConfiguration, EndpointType, HttpsConfiguration, MockResponseConfiguration, RouteConfiguration, ServerConfiguration, TcpListenerData, TestConfiguration, TlsVersion};
 
@@ -17,7 +17,7 @@ pub struct TestRow {
     // The process id of the test.
     pub process_id: Option<u32>,
     // The parameters of the test.
-    pub params: Option<Vec<String>>,
+    pub params: Option<Vec<String>>,    
 }
 
 impl TestRow {
@@ -53,8 +53,36 @@ impl From<TestConfiguration> for TestRow {
                 let mut params = f.iter().cloned().collect::<Vec<_>>();
                 params.sort();
                 params
-            }),
+            })        
         }
+    }
+}
+
+/**
+ * Predefined parameters.
+ */
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PredefinedSet {
+    // Name of the predefined set.
+    pub name: String,
+    // Parameters of the predefined set.
+    pub values: HashMap<String, String>,
+}
+
+impl PredefinedSet {
+    /**
+     * Create a new predefined set.
+     *
+     * # Arguments
+     * `name` - The name of the predefined set.
+     * `values` - The parameters of the predefined set.
+     *
+     * # Returns
+     * `PredefinedSet` - The predefined set.
+     */
+    pub fn new(name: &str, values: HashMap<String, String>) -> Self {
+        Self { name: name.to_string(), values }
     }
 }
 

--- a/apinae-ui/src/components/Tests.vue
+++ b/apinae-ui/src/components/Tests.vue
@@ -218,7 +218,7 @@ const removeParameter = (param) => {
                                                     role="group">
                                                     <button class="btn btn-sm btn-outline-danger text-decoration-none"
                                                         @click="confirmDelete(test)"><i
-                                                            class="fa-solid fa-minus"></i></button>
+                                                            class="fa-solid fa-trash"></i></button>
                                                 </div>
                                             </div>
                                         </span>


### PR DESCRIPTION
Adds the ability to edit parameter sets in the UI. This includes adding,
removing, and modifying parameter sets. The UI has been updated to
reflect these changes, and the backend has been updated to support the
new functionality.

This commit also includes the following changes:
    - New tab for editing parameter sets
    - Listing parameter sets in the UI
    - Adding and removing parameter sets
    - Updating parameter sets
    
Future improvements: None
    
Breaking changes: None
    
Resolves: #65
