### PR TITLE
fix: fix predefined set not correctly identified

### DIFF
--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -171,7 +171,7 @@ fn validate_parameters(test: &TestConfiguration, args: &Args) -> Result<Vec<(Str
         return Ok(Vec::new());
     }    
     for required_param in test_params_required {
-        if !args.param.iter().any(|(key, _)| key.eq(required_param)) {
+        if !test_params.iter().any(|(key, _)| key.eq(required_param)) {
             return Err(ApplicationError::CouldNotFind(format!("Missing parameter: {required_param}")));
         }
     }
@@ -318,5 +318,14 @@ mod test {
         assert_eq!(validate_parameters(config.tests.first().unwrap(), &args_missing_param1), Err(ApplicationError::CouldNotFind("Missing parameter: param1".to_string())));
         let args_params_ok = Args::parse_from(["apinae-daemon", "--file", "./tests/resources/test_http_mock.json", "--id", "1", "--param", "param2=2", "--param", "param1=1"]);
         assert_eq!(validate_parameters(config.tests.first().unwrap(), &args_params_ok), Ok(vec![("param2".to_string(), "2".to_string()), ("param1".to_string(), "1".to_string())]));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_validate_parameter_set() {
+        let config: AppConfiguration = AppConfiguration::load("./tests/resources/test_predefined_set.json").unwrap();
+        let args_missing_param = Args::parse_from(["apinae-daemon", "--file", "./tests/resources/test_predefined_set.json", "--id", "1"]);
+        assert!(validate_parameters(config.tests.first().unwrap(), &args_missing_param).is_err());
+        let args_missing_param1 = Args::parse_from(["apinae-daemon", "--file", "./tests/resources/test_predefined_set.json", "--id", "1", "--predefined-set", "not_found"]);
+        assert!(validate_parameters(config.tests.first().unwrap(), &args_missing_param1).is_ok());
     }
 }

--- a/apinae-daemon/tests/resources/test_predefined_set.json
+++ b/apinae-daemon/tests/resources/test_predefined_set.json
@@ -1,0 +1,60 @@
+{
+  "name": "Untitled",
+  "description": "",
+  "tests": [
+    {
+      "id": "1746310227365",
+      "name": "Untitled",
+      "description": "",
+      "servers": [
+        {
+          "id": "1746310308559",
+          "name": "error_system",
+          "httpPort": 8080,
+          "endpoints": [
+            {
+              "id": "1746310334217",
+              "pathExpression": "/",
+              "bodyExpression": null,
+              "method": "GET",
+              "endpointType": {
+                "mock": {
+                  "configuration": {
+                    "response": "{\n \"code\": \"${errorcode}\",\n \"text\": \"${errortext}\"\n}",
+                    "status": "200",
+                    "headers": {
+                      "X-FD-ERRORCODE": "${errorcode}"
+                    },
+                    "delay": 0
+                  }
+                }
+              }
+            }
+          ],
+          "httpsConfig": null
+        }
+      ],
+      "listeners": [],
+      "params": [
+        "errorcode",
+        "errortext"
+      ],
+      "predefinedParams": [
+        {
+          "name": "not_found",
+          "values": {
+            "errortext": "Not found",
+            "errorcode": "10"
+          }
+        },
+        {
+          "name": "technical_error",
+          "values": {
+            "errortext": "Internal server error",
+            "errorcode": "80"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/apinae-ui/src-tauri/test.apinae
+++ b/apinae-ui/src-tauri/test.apinae
@@ -1,0 +1,60 @@
+{
+  "name": "Untitled",
+  "description": "",
+  "tests": [
+    {
+      "id": "1746310227365",
+      "name": "Untitled",
+      "description": "",
+      "servers": [
+        {
+          "id": "1746310308559",
+          "name": "error_system",
+          "httpPort": 8080,
+          "endpoints": [
+            {
+              "id": "1746310334217",
+              "pathExpression": "/",
+              "bodyExpression": null,
+              "method": "GET",
+              "endpointType": {
+                "mock": {
+                  "configuration": {
+                    "response": "{\n \"code\": \"${errorcode}\",\n \"text\": \"${}\"\n}",
+                    "status": "200",
+                    "headers": {
+                      "X-FD-ERRORCODE": "${errorcode}"
+                    },
+                    "delay": 0
+                  }
+                }
+              }
+            }
+          ],
+          "httpsConfig": null
+        }
+      ],
+      "listeners": [],
+      "params": [
+        "errorcode",
+        "errortext"
+      ],
+      "predefinedParams": [
+        {
+          "name": "not_found",
+          "values": {
+            "errortext": "Not found",
+            "errorcode": "10"
+          }
+        },
+        {
+          "name": "technical_error",
+          "values": {
+            "errortext": "Internal server error",
+            "errorcode": "80"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes an issue where the predefined set was not correctly identified when starting the daemon. This was due to the fact that the predefined set was being overriden by the normal input parameters.

Future improvements: None

Breaking changes: None

Resolves: #72