### PR TITLE
fix: multiple errors shown if refresh fails

### DIFF
--- a/apinae-ui/src/components/Test.vue
+++ b/apinae-ui/src/components/Test.vue
@@ -99,13 +99,13 @@ const refresh = (testId) => {
     .then((message) => {
       httpServers.value = message;
     })
-    .catch((error) => window.alert(error));
+    .catch((error) => console.log(error));
 
   invoke("get_listeners", { testid: testId })
     .then((message) => {
       tcpListeners.value = message;
     })
-    .catch((error) => window.alert(error));
+    .catch((error) => console.log(error));
   invoke("get_predefined_sets", { testid: testId })
     .then((message) => {
       predefinedSets.value = message;
@@ -117,12 +117,12 @@ const refresh = (testId) => {
         }
       }
     })
-    .catch((error) => window.alert(error));
+    .catch((error) => console.log(error));
   invoke("load_settings", {})
     .then((message) => {
       settingsData.value.bodyHeight = message.bodyHeight;
     })
-    .catch((error) => window.alert(error));
+    .catch((error) => console.log(error));
 }
 
 //Updates the test by calling the update_test function in the backend.


### PR DESCRIPTION
Fixes the issue that multiple errors are shown if the refresh fails. This was caused by each of the refresh calls in the `refresh` method of the `Test.vue` component. Now only the get test call shows error dialog if error occurs, and the other refresh calls only log to the console.

This is a bug fix that improves the user experience by preventing multiple error dialogs from appearing when the refresh fails.

Future improvements: None

Breaking changes: None

Resolves: #77