### PR TITLE
fix: validation error on param statusCode

### DIFF
--- a/apinae-ui/src/components/Test.vue
+++ b/apinae-ui/src/components/Test.vue
@@ -527,8 +527,14 @@ const validateStringRequired = (str) => {
   return "is-invalid";
 }
 
+// Matches ${PARAM} in the string used for parameters.
+const REGEXP_PARAM = new RegExp("\\$\\{.*\\}", "g");
+
 //Verify that input is a number. 
 const validateNumberRequired = (str) => {
+  if (str && str.match(REGEXP_PARAM)) {
+    return "is-valid";
+  }
   if (typeof str === "number" || (str && (Number.isInteger(str) || (str.length > 0 && !isNaN(str))))) {
     return "is-valid";
   }


### PR DESCRIPTION
Fixes validation error when return a parameterized statusCode in the response object. The fix adds a check for the following regular expression: \$\{.*\}. This allows for the use of parameterized status codes such as ${statusCode} in the response object.

Future improvements: None

Breaking changes: None

Resolves: #75