### PR TITLE
feat: set parameters when running apinae UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4342,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4372,9 +4372,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5424,9 +5424,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",

--- a/apinae-daemon/Cargo.toml
+++ b/apinae-daemon/Cargo.toml
@@ -15,10 +15,10 @@ apinae-lib = { path = "../apinae-lib" }
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.45.0", features = ["full"] }
 regex = "1.11.1"
 actix-web = { version = "4.10.2", features = ["rustls-0_23"] }
-rustls = { version = "0.23.26", features = ["logging", "tls12"] }
+rustls = { version = "0.23.27", features = ["logging", "tls12"] }
 rustls-pemfile = "2.2.0"
 reqwest = { version = "0.12.15" }
 log = "0.4.27"

--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -164,7 +164,7 @@ fn list_tests(config: &AppConfiguration) {
  */
 async fn start_daemon(args: Args, config: &AppConfiguration) -> Result<(), ApplicationError> {
     let test_id = args.clone().id.ok_or(ApplicationError::CouldNotFind("Missing id".to_string()))?;
-    log::info!("Starting daemon with id: {} and args {:?}", test_id, args);
+    log::info!("Starting daemon with id: {test_id} and args {args:?}");
     let test = get_test(test_id.as_str(), config)?;
     let params = validate_parameters(test, &args)?;
     let mut server_setup = ServerSetup::new();

--- a/apinae-daemon/src/main.rs
+++ b/apinae-daemon/src/main.rs
@@ -164,6 +164,7 @@ fn list_tests(config: &AppConfiguration) {
  */
 async fn start_daemon(args: Args, config: &AppConfiguration) -> Result<(), ApplicationError> {
     let test_id = args.clone().id.ok_or(ApplicationError::CouldNotFind("Missing id".to_string()))?;
+    log::info!("Starting daemon with id: {} and args {:?}", test_id, args);
     let test = get_test(test_id.as_str(), config)?;
     let params = validate_parameters(test, &args)?;
     let mut server_setup = ServerSetup::new();


### PR DESCRIPTION
Allow users to set parameters when running apinae through the UI. When the user runs apinae through the UI and the test requires parameters, the UI will prompt the user to enter the parameters. The parameters will be passed to apinae when it is run.

Future improvements: Allow choosing preset parameters. Close parameter dialog when run. Remember last used parameters.

Breaking changes: None

Resolves: #63