### PR TITLE
feat: add delay to routes

### DIFF
--- a/apinae-daemon/src/server/http.rs
+++ b/apinae-daemon/src/server/http.rs
@@ -258,7 +258,7 @@ async fn route_request(route_configuration: &RouteConfiguration, req: HttpReques
     let client = get_client(route_configuration)?;
 
     if let Some(delay_before) = route_configuration.delay_before {
-        log::debug!("Waiting {}ms before request", delay_before);
+        log::debug!("Waiting {delay_before}ms before request");
         tokio::time::sleep(Duration::from_millis(delay_before)).await;
     }
 
@@ -267,7 +267,7 @@ async fn route_request(route_configuration: &RouteConfiguration, req: HttpReques
     let response = get_response(response).await?;
 
     if let Some(delay_after) = route_configuration.delay_after {
-        log::debug!("Waiting {}ms after request", delay_after);
+        log::debug!("Waiting {delay_after}ms after request");
         tokio::time::sleep(Duration::from_millis(delay_after)).await;
     }
 

--- a/apinae-daemon/src/server/http.rs
+++ b/apinae-daemon/src/server/http.rs
@@ -257,9 +257,19 @@ async fn route_request(route_configuration: &RouteConfiguration, req: HttpReques
 
     let client = get_client(route_configuration)?;
 
+    if let Some(delay_before) = route_configuration.delay_before {
+        log::debug!("Waiting {}ms before request", delay_before);
+        tokio::time::sleep(Duration::from_millis(delay_before)).await;
+    }
+
     let response = client.execute(request).await.map_err(|err| ApplicationError::RoutingError(format!("Error executing client request: {err}")))?;
 
     let response = get_response(response).await?;
+
+    if let Some(delay_after) = route_configuration.delay_after {
+        log::debug!("Waiting {}ms after request", delay_after);
+        tokio::time::sleep(Duration::from_millis(delay_after)).await;
+    }
 
     Ok(response)
 }
@@ -670,14 +680,14 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_get_client_no_proxy() {
-        let route_configuration = RouteConfiguration::new("http://localhost:8080".to_owned(), None, None, false, false, false, None, None, None, None);
+        let route_configuration = RouteConfiguration::new("http://localhost:8080".to_owned(), None, None, false, false, false, None, None, None, None, None, Some(10));
         let client = get_client(&route_configuration);
         assert!(client.is_ok());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_get_client_with_proxy() {
-        let route_configuration = RouteConfiguration::new("http://localhost:8080".to_owned(), Some("http_//proxy.com:9999".to_owned()), None, false, false, false, None, None, None, None);
+        let route_configuration = RouteConfiguration::new("http://localhost:8080".to_owned(), Some("http_//proxy.com:9999".to_owned()), None, false, false, false, None, None, None, None, None, Some(100));
         let client = get_client(&route_configuration);
         assert!(client.is_ok());
     }

--- a/apinae-lib/src/config.rs
+++ b/apinae-lib/src/config.rs
@@ -900,6 +900,10 @@ pub struct RouteConfiguration {
     pub read_timeout: Option<u64>,
     // Connect timeout
     pub connect_timeout: Option<u64>,
+    // Delay before request in milliseconds
+    pub delay_before: Option<u64>,
+    // Delay after request in milliseconds
+    pub delay_after: Option<u64>,    
 }
 
 impl RouteConfiguration {
@@ -916,6 +920,8 @@ impl RouteConfiguration {
      * `max_tls_version` Maximum TLS version
      * `read_timeout` Read timeout
      * `connect_timeout` Connect timeout
+     * `delay_before` Delay before request in milliseconds
+     * `delay_after` Delay after request in milliseconds
      *
      */
     #[allow(clippy::too_many_arguments)]
@@ -932,8 +938,10 @@ impl RouteConfiguration {
         max_tls_version: Option<TlsVersion>,
         read_timeout: Option<u64>,
         connect_timeout: Option<u64>,
+        delay_before: Option<u64>,
+        delay_after: Option<u64>,
     ) -> Self {
-        RouteConfiguration { url, proxy_url, log, http1_only, accept_invalid_certs, accept_invalid_hostnames, min_tls_version, max_tls_version, read_timeout, connect_timeout }
+        RouteConfiguration { url, proxy_url, log, http1_only, accept_invalid_certs, accept_invalid_hostnames, min_tls_version, max_tls_version, read_timeout, connect_timeout, delay_before, delay_after }
     }
 }
 
@@ -996,7 +1004,7 @@ mod test {
                         Some("/test".to_string()),
                         Some("GET".to_string()),
                         Some("Body".to_string()),
-                        Some(EndpointType::Route { configuration: RouteConfiguration::new("/test".to_string(), None, None, false, false, false, None, None, None, None) }),
+                        Some(EndpointType::Route { configuration: RouteConfiguration::new("/test".to_string(), None, None, false, false, false, None, None, None, None, Some(10), Some(100)) }),
                     )
                     .unwrap()],
                     None,                    
@@ -1023,7 +1031,7 @@ mod test {
         assert_eq!(configuration.tests[0].servers[0].endpoints[0].body_expression, Some("Body".to_owned()));
         assert_eq!(
             configuration.tests[0].servers[0].endpoints[0].endpoint_type,
-            Some(EndpointType::Route { configuration: RouteConfiguration::new("/test".to_string(), None, None, false, false, false, None, None, None, None,) })
+            Some(EndpointType::Route { configuration: RouteConfiguration::new("/test".to_string(), None, None, false, false, false, None, None, None, None, Some(10), Some(100)) })
         );
     }
 

--- a/apinae-ui/src-tauri/src/model.rs
+++ b/apinae-ui/src-tauri/src/model.rs
@@ -242,6 +242,10 @@ pub struct RouteRow {
     pub read_timeout: Option<u64>,
     // The connect timeout.
     pub connect_timeout: Option<u64>,
+    // The delay before the request.
+    pub delay_before: Option<u64>,
+    // The delay after the request.
+    pub delay_after: Option<u64>,
 }
 
 impl From<&RouteConfiguration> for RouteRow {
@@ -259,6 +263,8 @@ impl From<&RouteConfiguration> for RouteRow {
             max_tls_version: route.max_tls_version.clone().map(String::from),
             read_timeout: route.read_timeout,
             connect_timeout: route.connect_timeout,
+            delay_before: route.delay_before,
+            delay_after: route.delay_after,
         }
     }
 }
@@ -279,6 +285,8 @@ impl From<&RouteRow> for RouteConfiguration {
             route.max_tls_version.clone().map(TlsVersion::from),
             route.read_timeout,
             route.connect_timeout,
+            route.delay_before,
+            route.delay_after,
         )
     }
 }
@@ -425,7 +433,7 @@ mod test {
 
     #[test]
     fn test_route_row_from_route_configuration() {
-        let route_config = RouteConfiguration::new("url".to_owned(), None, None, false, false, false, Some(TlsVersion::TLSv1_2), Some(TlsVersion::TLSv1_1), None, None);
+        let route_config = RouteConfiguration::new("url".to_owned(), None, None, false, false, false, Some(TlsVersion::TLSv1_2), Some(TlsVersion::TLSv1_1), None, None, Some(10), Some(20));
 
         let route_row = RouteRow::from(&route_config);
 
@@ -438,6 +446,9 @@ mod test {
         assert_eq!(route_row.max_tls_version, Some("TLSv1.1".to_owned()));
         assert_eq!(route_row.read_timeout, None);
         assert_eq!(route_row.connect_timeout, None);
+        assert_eq!(route_row.delay_before, Some(10));
+        assert_eq!(route_row.delay_after, Some(20));
+
     }
 
     /**

--- a/apinae-ui/src/components/Test.vue
+++ b/apinae-ui/src/components/Test.vue
@@ -392,7 +392,9 @@ const convertRouteToRequestObject = (routeData) => {
     minTlsVersion: routeData.value.minTlsVersion,
     maxTlsVersion: routeData.value.maxTlsVersion,
     readTimeout: routeData.value.readTimeout ? parseInt(routeData.value.readTimeout) : null,
-    connectTimeout: routeData.value.connectTimeout ? parseInt(routeData.value.connectTimeout) : null
+    connectTimeout: routeData.value.connectTimeout ? parseInt(routeData.value.connectTimeout) : null,
+    delayBefore: routeData.value.delayBefore ? parseInt(routeData.value.delayBefore) : null,
+    delayAfter: routeData.value.delayAfter ? parseInt(routeData.value.delayAfter) : null,
   }
 }
 
@@ -868,6 +870,10 @@ const setSelectedPredefinedSet = (predefinedSet) => {
                                         <dd class="col-sm-4 small">{{ endpoint.route?.readTimeout }}</dd>
                                         <dt class="col-sm-2 small">Connect timeout</dt>
                                         <dd class="col-sm-4 small">{{ endpoint.route?.connectTimeout }}</dd>
+                                        <dt class="col-sm-2 small">Delay before request (ms)</dt>
+                                        <dd class="col-sm-4 small">{{ endpoint.route?.delayBefore }}</dd>
+                                        <dt class="col-sm-2 small">Delay after request (ms)</dt>
+                                        <dd class="col-sm-4 small">{{ endpoint.route?.delayAfter }}</dd>                                        
                                       </dl>
                                     </div>
                                   </div>
@@ -1237,8 +1243,6 @@ const setSelectedPredefinedSet = (predefinedSet) => {
               </div>
             </div>
             <div class="col-md-6" v-if="!showEditMockData">
-            </div>
-            <div class="col-md-6" v-if="!showEditMockData">
               <label for="idEditMinTlsVersion" class="form-label small">Min Tls version&nbsp;</label>
               <select id="idEditMinTlsVersion" class="form-select form-select-sm is-valid"
                 v-model="editRouteData.minTlsVersion">
@@ -1263,7 +1267,17 @@ const setSelectedPredefinedSet = (predefinedSet) => {
               <label class="form-label small" for="idEditConnectTimeout">Connect timeout</label>
               <input class="form-control form-control-sm" type="test" id="idEditConnectTimeout"
                 v-model="editRouteData.connectTimeout" :class="validateNumberOptional(editRouteData.connectTimeout)">
+            </div>        
+            <div class="col-md-6" v-if="!showEditMockData">
+              <label class="form-label small" for="idEditBeforeDelay">Delay before request (ms)</label>
+              <input class="form-control form-control-sm" type="text" id="idEditBeforeDelay"
+                v-model="editRouteData.delayBefore" :class="validateNumberOptional(editRouteData.delayBefore)">
             </div>
+            <div class="col-md-6" v-if="!showEditMockData">
+              <label class="form-label small" for="idEditAfterDelay">Delay before after (ms)</label>
+              <input class="form-control form-control-sm" type="test" id="idEditAfterDelay"
+                v-model="editRouteData.delayAfter" :class="validateNumberOptional(editRouteData.delayAfter)">
+            </div>                                  
           </form>
         </div>
         <div class="modal-footer bg-primary-subtle">


### PR DESCRIPTION
Adds delay before request and request after response to routes. This allows for testing of the delay features. The ui has been updated to allow for setting the delays in the route editor. The delay is set in milliseconds and can be set to 0 or none for no delay.

Future improvements: None

Breaking changes: None

Resolves: #82