### PR TITLE
docs: improve documentation

### DIFF
--- a/docs/content/examples/simple_http_server.md
+++ b/docs/content/examples/simple_http_server.md
@@ -1,1 +1,0 @@
-# Http server setup

--- a/docs/content/examples/simple_https_server.md
+++ b/docs/content/examples/simple_https_server.md
@@ -1,1 +1,0 @@
-# Http server setup

--- a/docs/content/examples/simple_mock_http_server.md
+++ b/docs/content/examples/simple_mock_http_server.md
@@ -1,0 +1,86 @@
+## Description
+This creates a simple http server on port 8080.
+```"httpPort": 8080,```
+
+It responds on method GET, all input bodies and on path / .
+"pathExpression": "/",
+"bodyExpression": null,
+"method": "GET",
+
+It will respond with the following body
+```
+{
+  "id": "1",
+  "description": "Description text"
+}
+```
+and
+header ```Content-Type: application/json```
+
+It will respond with no wait because of
+```"delay": 0```
+
+## Running and testing the setup
+```apinae --file <FILE> --id 1747239324846```
+
+```curl -i http://localhost:8080 ```
+
+returns
+```
+HTTP/1.1 200 OK
+content-length: 52
+content-type: application/json
+date: Wed, 14 May 2025 16:43:34 GMT
+
+{
+  "id": "1",
+  "description": "Description text"
+}
+```
+
+
+## Full configuration
+```
+{
+  "name": "Untitled",
+  "description": "",
+  "setups": [
+    {
+      "id": "1747239324846",
+      "name": "Untitled",
+      "description": "",
+      "servers": [
+        {
+          "id": "1747239330993",
+          "name": "Http server",
+          "httpPort": 8080,
+          "endpoints": [
+            {
+              "id": "1747239489034",
+              "pathExpression": "/",
+              "bodyExpression": null,
+              "method": "GET",
+              "endpointType": {
+                "mock": {
+                  "configuration": {
+                    "response": "{\n  \"id\": \"1\",\n  \"description\": \"Description text\"\n}",
+                    "status": "200",
+                    "headers": {
+                      "Content-Type": "application/json"
+                    },
+                    "delay": 0
+                  }
+                }
+              }
+            }
+          ],
+          "httpsConfig": null
+        }
+      ],
+      "listeners": [],
+      "params": null,
+      "predefinedParams": null
+    }
+  ]
+}
+```

--- a/docs/content/examples/simple_route_http_server.md
+++ b/docs/content/examples/simple_route_http_server.md
@@ -1,0 +1,85 @@
+## Description
+This creates a simple http server on port 8080.
+```"httpPort": 8080,```
+
+It responds on method GET, all input bodies and on path / .
+```
+"pathExpression": "/",
+"bodyExpression": null,
+"method": "GET",
+```
+
+It will route to an apache webserver on port 80
+```
+"route": {
+    "configuration": {
+    "url": "http://localhost:80",
+    "http1Only": false,
+    "acceptInvalidCerts": false,
+    "acceptInvalidHostnames": false,
+    }
+}
+```
+
+## Running and testing the setup
+```
+apinae --file <FILE> --id 1747239324846
+```
+
+```
+curl -i http://localhost:8080
+```
+
+returns
+```
+HTTP/1.1 200 OK
+content-length: 481
+date: Wed, 14 May 2025 20:27:47 GMT
+content-type: text/html;charset=ISO-8859-1
+server: Apache/2.4.63 (Unix)
+```
+
+
+## Full configuration
+```
+{
+  "name": "Untitled",
+  "description": "",
+  "setups": [
+    {
+      "id": "1747239324846",
+      "name": "Untitled",
+      "description": "",
+      "servers": [
+        {
+          "id": "1747239330993",
+          "name": "Http server",
+          "httpPort": 8080,
+          "endpoints": [
+            {
+              "id": "1747239489034",
+              "pathExpression": "/**",
+              "bodyExpression": null,
+              "method": "GET",
+              "endpointType": {
+                "route": {
+                  "configuration": {
+                    "url": "http://localhost:80",
+                    "http1Only": false,
+                    "acceptInvalidCerts": false,
+                    "acceptInvalidHostnames": false
+                  }
+                }
+              }
+            }
+          ],
+          "httpsConfig": null
+        }
+      ],
+      "listeners": [],
+      "params": null,
+      "predefinedParams": null
+    }
+  ]
+}
+```

--- a/docs/content/tutorials/creating_and_running_a_simple_test.md
+++ b/docs/content/tutorials/creating_and_running_a_simple_test.md
@@ -1,1 +1,0 @@
-# Creating and running a test

--- a/docs/content/tutorials/parameterized_test.md
+++ b/docs/content/tutorials/parameterized_test.md
@@ -1,0 +1,90 @@
+## Description
+This tutorial shows how to use parameters in the test. Parameters are used to create a single response which changes
+based on the parameters given when starting the setup.
+
+## Setup
+Server setup.
+
+```
+        {
+          "id": "1747239330993",
+          "name": "Http server",
+          "httpPort": 8080,
+          "endpoints": [
+            {
+              "id": "1747255333650",
+              "pathExpression": "/**",
+              "bodyExpression": null,
+              "method": "GET",
+              "endpointType": {
+                "mock": {
+                  "configuration": {
+                    "response": "{\n  \"errorcode\": \"${errorcode}\",\n  \"errortext\": \"${errortext}\"\n}",
+                    "status": "${statuscode}",
+                    "headers": {
+                      "Content-Type": "application/json"
+                    },
+                    "delay": 0
+                  }
+                }
+              }
+            }
+          ],
+          "httpsConfig": null
+        }
+```
+
+There are now three parameters defined in the setup.
+- ${errorcode}
+- ${errortext}
+- ${statuscode}
+
+These will be replaced with the values given as input arguments.
+
+## Parameters
+These parameters are required, it not given no replacements will be done. They must have the same names as given for the replacement texts ${<PARAMETER_NAME>}.
+
+```
+"params": [
+   "errortext",
+   "statuscode",
+   "errorcode"
+],
+```
+
+## Starting the daemon
+
+Starting the daemon without arguments will cause the daemon to fail.
+```
+apinae --file <FILE> --id 1747239324846
+```
+```
+Error: CouldNotFind("Missing parameter: errorcode")
+```
+
+To get the daemon to run key values must be given.
+```
+apinae --file /home/kjetil/Documents/test.apinae --id 1747239324846 \
+--param errorcode=10 --param errortext="Not found" --param statuscode=404 
+```
+
+The daemon now starts. Running the request below
+```
+curl -i http://localhost:8080
+```
+
+the following is returned.
+```
+HTTP/1.1 404 Not Found
+content-length: 51
+content-type: application/json
+date: Wed, 14 May 2025 20:59:03 GMT
+
+{
+  "errorcode": "10",
+  "errortext": "Not found"
+}
+```
+
+## Conclusion
+Parameterized tests allows us to reuse the same setup for multiple scenarios.

--- a/docs/content/tutorials/simulate_receive_timeout_with_mock.md
+++ b/docs/content/tutorials/simulate_receive_timeout_with_mock.md
@@ -1,0 +1,43 @@
+## Description
+Receive timeouts are a normal situation which needs to be tested. Apinae supports this with the delay parameter.
+
+## Setup
+
+The important element is the delay. This is the delay the application waits before sending the response in milliseconds.
+
+```
+{
+    "id": "1747255333650",
+    "pathExpression": "/**",
+    "bodyExpression": null,
+    "method": "GET",
+    "endpointType": {
+    "mock": {
+        "configuration": {
+        "response": "{\n  \"errorcode\": \"10\",\n  \"errortext\": \"Not found\"\n}",
+        "status": "404",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "delay": 30000
+        }
+    }
+    }
+}
+```
+
+## Testing the setups
+Start the application normally.
+
+```
+apinae --file <FILE> --id 1747239324846
+```
+
+Test the timeout by running
+```
+curl --max-time 5 -i http://localhost:8080
+```
+which results in
+```
+curl: (28) Operation timed out after 5002 milliseconds with 0 bytes received
+```


### PR DESCRIPTION
This commit adds documentation for the following:
- Examples:
  - simple_mock_http_server
  - simple_route_http_server
- Tutorials:
  - parameterized_test
  - simulate_receive_timeout_with_mock

Future improvements: None

Breaking changes: None

Resolves: #93