### PR TITLE
build: improve-build-scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,18 @@ jobs:
         run: |
           sudo apt-get update  
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
       - name: Install tinyproxy
         run: sudo apt install tinyproxy            
       - name: Install dependencies
         run: cargo fetch
+      - name: Set version
+        run: cargo set-version 
+      - name: Set version        
+        run: |
+            VERSION=${{ github.ref_name }}
+            cargo set-version ${VERSION#v}
       - name: install frontend dependencies
         run: npm install --prefix apinae-ui      
       - name: Build daemon

--- a/apinae-ui/src-tauri/tauri.conf.json
+++ b/apinae-ui/src-tauri/tauri.conf.json
@@ -4,8 +4,8 @@
   "version": "0.1.16",
   "identifier": "net.forgottendonkey.apinae",
   "build": {
-    "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build",
+    "beforeDevCommand": "npm run dev --prefix apinae-ui",
+    "beforeBuildCommand": "npm run build  --prefix apinae-ui",
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist"
   },


### PR DESCRIPTION
Updates release so that version is retrived from the tag. It installs cargo-edit where we use set-version. Version set is always the tag version with v removed.

Fixes the tauri build due to a change in latest tauri-cli. Now prefix is added so it no longer fails on npm run build.

Breaking changes: None

Resolves: #111